### PR TITLE
Part 12: Audio & Polish — procedural SFX, loading screen, easing, micro-interactions

### DIFF
--- a/docs/part12-medium.md
+++ b/docs/part12-medium.md
@@ -1,0 +1,181 @@
+3D Profile Website — Part 12: Make It Delightful with Procedural Audio, a Real Loading Screen & Micro-Interactions
+
+Welcome back — and this is the finale of the 3D Profile Website series!
+
+The room is fast (Part 10), works on a phone (Part 11), and every model is intact. What’s left is the layer that separates “a demo” from “a product”: the little touches you don’t consciously notice but absolutely feel. In Part 12 we add the polish:
+
+• Procedural sound effects with the Web Audio API — clicks, whooshes, opens — with zero audio files
+• A mute toggle that respects the browser’s autoplay rules and remembers your choice
+• A real loading screen — branded, with an animated progress bar, instead of “Loading 47%”
+• Cinematic camera easing so views glide instead of snapping
+• Micro-interactions — buttons that lift, cubes that swell on hover
+
+None of this is hard. All of it matters. Let’s finish strong.
+
+—  —  —
+
+Step 1 — Sound With No Sound Files
+
+Audio is the fastest way to make an interface feel alive — and the fastest way to bloat your bundle with megabytes of MP3s. We skip the files entirely: the Web Audio API can synthesize every UI sound from an oscillator and a gain envelope. A click is just a short tone with a fast attack and decay.
+
+The whole engine is one helper:
+
+    // src/audio/sound.ts
+    let ctx = null
+
+    function getCtx() {
+      if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)()
+      if (ctx.state === 'suspended') void ctx.resume()   // unlock after a gesture
+      return ctx
+    }
+
+    function blip({ freq, dur, type = 'sine', gain = 0.05, sweep = 0 }) {
+      if (useAudio.getState().muted) return
+      const ac = getCtx(); if (!ac) return
+      const t = ac.currentTime
+      const osc = ac.createOscillator()
+      const g = ac.createGain()
+      osc.type = type
+      osc.frequency.setValueAtTime(freq, t)
+      if (sweep) osc.frequency.exponentialRampToValueAtTime(freq + sweep, t + dur)
+      g.gain.setValueAtTime(0.0001, t)                          // fade in from ~0
+      g.gain.exponentialRampToValueAtTime(gain, t + 0.01)       // fast attack
+      g.gain.exponentialRampToValueAtTime(0.0001, t + dur)      // smooth decay
+      osc.connect(g).connect(ac.destination)
+      osc.start(t); osc.stop(t + dur + 0.03)
+    }
+
+That exponentialRampToValueAtTime envelope is the whole trick — start and end at near-zero (not exactly zero, exponential ramps can’t reach 0) so there’s no click-pop, and you get a soft musical blip. From that one primitive, a tiny vocabulary of sounds:
+
+    export const sfx = {
+      click:  () => blip({ freq: 430, dur: 0.08, type: 'triangle', sweep: 90 }),
+      hover:  () => blip({ freq: 720, dur: 0.04, gain: 0.018 }),
+      whoosh: () => { /* two stacked tones sweeping up — camera flying */ },
+      open:   () => { /* rising pair — a panel appears */ },
+      close:  () => blip({ freq: 480, dur: 0.14, sweep: -260 }),  // falling = closing
+    }
+
+Pitch carries meaning. Sweeping up reads as “opening / arriving”, sweeping down as “closing / leaving”. Your ear decodes direction before your brain reads the label — so close falls and open rises.
+
+The autoplay rule you can’t skip
+
+Browsers block all audio until the user interacts with the page — an AudioContext created on load starts suspended. So we create/resume it lazily, on the first real gesture, and call a tiny primeAudio() from the first click handler. The very first sound on page load is silently dropped (no gesture yet); every one after plays. Don’t fight this — design around it.
+
+Wiring it in
+
+Each interaction picks the sound that matches its meaning, not its widget:
+
+    const onNav = (v) => { primeAudio(); sfx.whoosh(); /* fly camera */ }   // travel
+    startTour:  () => { sfx.open() }       // something begins
+    exit/close: () => { sfx.close() }      // something ends
+    openSeries: () => { sfx.open() }       // drawer slides in
+
+Because the sounds live in a plain module (not a hook), a 3D mesh inside the Canvas calls sfx.click() exactly the same way a DOM button does — no context plumbing across the renderer boundary.
+
+—  —  —
+
+Step 2 — A Mute Toggle That Remembers
+
+Sound must always be dismissible, and the choice should stick. A four-line zustand store with localStorage does both, and — being a store — it’s readable from the synthesis code and the button:
+
+    // src/store/useAudio.ts
+    export const useAudio = create((set) => ({
+      muted: localStorage.getItem('hadi-3d-muted') === '1',
+      toggleMute: () => set((s) => {
+        const muted = !s.muted
+        localStorage.setItem('hadi-3d-muted', muted ? '1' : '0')
+        return { muted }
+      }),
+    }))
+
+blip() checks useAudio.getState().muted and bails before touching the audio context, so muting is instant and total. The button is a speaker pill that nudges on hover — itself a micro-interaction (Step 5).
+
+Default to on, but make off one tap away and persistent. A muted-by-default portfolio loses the delight; an un-mutable one loses the visitor. Respect the toggle and remember it.
+
+—  —  —
+
+Step 3 — A Loading Screen Worth the Wait
+
+drei’s useProgress() hands you { progress, active } for free. The old loader spent it on bare text — “Loading 47%”. The first thing a visitor sees deserves better, and it costs nothing but CSS:
+
+    const { progress, active } = useProgress()
+    const pct = Math.round(progress)
+
+    <Html center>
+      <div /* branded card: gradient, name in gold gradient-text */>
+        Hadi Halim · 3D Portfolio
+        <div /* track */>
+          <div style={{ width: `${pct}%`, transition: 'width 0.25s ease-out',
+                        background: 'linear-gradient(90deg,#ffd27a,#ffb347)' }} />
+        </div>
+        <span>{active ? 'Memuat ruangan…' : 'Hampir siap…'}</span>
+        <span>{pct}%</span>
+      </div>
+    </Html>
+
+Two details do the heavy lifting: a transition: width 0.25s so the bar glides between progress jumps instead of teleporting, and a gentle keyframes pulse on the status text so the screen feels alive even when a big GLB stalls the number. The brand name uses gradient-clipped text (background-clip: text) — a free touch of premium.
+
+—  —  —
+
+Step 4 — Cinematic Camera Easing
+
+The camera already animates between views (Part 8). CameraControls exposes smoothTime — the seconds it eases toward a target — and we’d been on the snappy default. Bumping it makes every fly-to feel directed:
+
+    <CameraControls
+      smoothTime={0.5}            // cinematic glide between view presets
+      draggingSmoothTime={0.12}   // but keep manual rotation crisp
+      makeDefault
+    />
+
+The split matters: slow the scripted transitions, keep the direct manipulation fast. A 0.5 s glide when you click “Experience” feels expensive and intentional; a 0.5 s lag while you drag would feel broken. Different smoothing for different intents.
+
+—  —  —
+
+Step 5 — Micro-Interactions: the 2-Pixel Difference
+
+The smallest changes give the most “feel”. Two examples.
+
+DOM buttons lift on hover. A 2 px rise and a quick transition turns a flat target into something that responds to your cursor:
+
+    onMouseOver={(e) => (e.currentTarget.style.transform = 'translateY(-2px)')}
+    onMouseOut={(e)  => (e.currentTarget.style.transform = 'translateY(0)')}
+    style={{ transition: 'background 0.2s, color 0.2s, transform 0.15s' }}
+
+3D objects swell on hover — but smoothly, lerped per-frame, never a snap. The social cubes already track a hovered flag for their tooltip; one line in their existing useFrame makes them breathe:
+
+    useFrame((_, dt) => {
+      ref.current.rotation.y += spin * dt
+      const target = hovered && active ? 1.16 : 1
+      const s = THREE.MathUtils.damp(ref.current.scale.x, target, 10, dt)  // frame-rate-independent
+      ref.current.scale.setScalar(s)
+    })
+
+THREE.MathUtils.damp, not lerp. damp(current, target, lambda, dt) is the frame-rate-independent cousin of lerp — it eases the same on a 144 Hz monitor and a 30 fps phone. Any time you smooth toward a target in useFrame, reach for damp and pass dt. (And pair the swell with a soft hover blip, gated to the focused view so it never becomes noise.)
+
+—  —  —
+
+Lessons Learned in Part 12
+
+• Synthesize UI sound, don’t ship it. The Web Audio API turns an oscillator + a gain envelope into clicks, whooshes, and opens — kilobytes of code instead of megabytes of MP3.
+• Pitch direction is language: sweep up to open, down to close. Ears read it before eyes read the label.
+• Respect the autoplay rule. Create/resume the AudioContext on the first gesture; let the very first sound drop.
+• Sound must be mutable and sticky — a tiny persisted store, checked before you make a peep.
+• A loading screen is your first impression — brand it, animate the bar’s width, pulse the status. It’s all CSS.
+• Smooth scripted motion, keep manual motion crisp — smoothTime vs draggingSmoothTime.
+• Micro-interactions are 2 pixels and one line. Lift DOM buttons on hover; damp 3D objects toward a hover scale. Small, smooth, frame-rate-independent.
+
+—  —  —
+
+The End — and What You’ve Built
+
+Twelve parts ago this was an empty <Canvas>. Now it’s a navigable, interactive, fast, mobile-friendly, delightful 3D portfolio: a room you can tour, a desktop you can click, a résumé you can read, tutorials you can open, lights you can flip — and now, one that sounds and feels like a finished product.
+
+Everything except the final mile — deployment — is done. Put it behind a URL and let it speak for you. Thanks for building the whole thing alongside me.
+
+—  —  —
+
+Asset Credits
+
+• Sound — synthesized at runtime with the Web Audio API (no files)
+• Loading progress — useProgress from @react-three/drei
+• State — zustand

--- a/docs/part12.md
+++ b/docs/part12.md
@@ -1,0 +1,197 @@
+# 3D Profile Website - Part 12: Make It Delightful — Procedural Audio, a Real Loading Screen & Micro-Interactions
+
+Welcome back — and this is the **finale** of the 3D Profile Website series!
+
+The room is fast (Part 10), works on a phone (Part 11), and every model is intact. What's left is the layer that separates "a demo" from "a *product*": the little touches you don't consciously notice but absolutely feel. In **Part 12** we add the polish:
+
+✅ **Procedural sound effects** with the Web Audio API — clicks, whooshes, opens — **with zero audio files**
+✅ A **mute toggle** that respects the browser's autoplay rules and remembers your choice
+✅ A **real loading screen** — branded, with an animated progress bar, instead of "Loading 47%"
+✅ **Cinematic camera easing** so views glide instead of snapping
+✅ **Micro-interactions** — buttons that lift, cubes that swell on hover
+
+None of this is hard. All of it matters. Let's finish strong.
+
+---
+
+## Step 1 — Sound With No Sound Files
+
+Audio is the fastest way to make an interface feel *alive* — and the fastest way to bloat your bundle with megabytes of MP3s. We skip the files entirely: the **Web Audio API** can *synthesize* every UI sound from an oscillator and a gain envelope. A click is just a short tone with a fast attack and decay.
+
+The whole engine is one helper:
+
+```ts
+// src/audio/sound.ts
+let ctx: AudioContext | null = null
+
+function getCtx(): AudioContext | null {
+  if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)()
+  if (ctx.state === 'suspended') void ctx.resume()   // unlock after a gesture
+  return ctx
+}
+
+function blip({ freq, dur, type = 'sine', gain = 0.05, sweep = 0 }) {
+  if (useAudio.getState().muted) return
+  const ac = getCtx(); if (!ac) return
+  const t = ac.currentTime
+  const osc = ac.createOscillator()
+  const g = ac.createGain()
+  osc.type = type
+  osc.frequency.setValueAtTime(freq, t)
+  if (sweep) osc.frequency.exponentialRampToValueAtTime(freq + sweep, t + dur)
+  g.gain.setValueAtTime(0.0001, t)                          // fade in from ~0
+  g.gain.exponentialRampToValueAtTime(gain, t + 0.01)       // fast attack
+  g.gain.exponentialRampToValueAtTime(0.0001, t + dur)      // smooth decay
+  osc.connect(g).connect(ac.destination)
+  osc.start(t); osc.stop(t + dur + 0.03)
+}
+```
+
+That `exponentialRampToValueAtTime` envelope is the whole trick — start and end at *near*-zero (not exactly zero, exponential ramps can't reach 0) so there's no click-pop, and you get a soft musical blip. From that one primitive, a tiny vocabulary of sounds:
+
+```ts
+export const sfx = {
+  click:  () => blip({ freq: 430, dur: 0.08, type: 'triangle', sweep: 90 }),
+  hover:  () => blip({ freq: 720, dur: 0.04, gain: 0.018 }),
+  whoosh: () => { /* two stacked tones sweeping up — camera flying */ },
+  open:   () => { /* rising pair — a panel appears */ },
+  close:  () => blip({ freq: 480, dur: 0.14, sweep: -260 }),  // falling = closing
+}
+```
+
+> 🎚️ **Pitch carries meaning.** Sweeping *up* reads as "opening / arriving", sweeping *down* as "closing / leaving". Your ear decodes direction before your brain reads the label — so `close` falls and `open` rises.
+
+### The autoplay rule you can't skip
+
+Browsers **block all audio until the user interacts with the page** — an `AudioContext` created on load starts `suspended`. So we create/resume it lazily, on the first real gesture, and call a tiny `primeAudio()` from the first click handler. The very first sound on page load is silently dropped (no gesture yet); every one after plays. Don't fight this — design around it.
+
+### Wiring it in
+
+Each interaction picks the sound that matches its *meaning*, not its widget:
+
+```tsx
+const onNav = (v) => { primeAudio(); sfx.whoosh(); /* fly camera */ }   // travel
+startTour:  () => { sfx.open() }       // something begins
+exit/close: () => { sfx.close() }      // something ends
+openSeries: () => { sfx.open() }       // drawer slides in
+```
+
+Because the sounds live in a plain module (not a hook), a **3D mesh** inside the Canvas calls `sfx.click()` exactly the same way a **DOM button** does — no context plumbing across the renderer boundary.
+
+---
+
+## Step 2 — A Mute Toggle That Remembers
+
+Sound must always be **dismissible**, and the choice should stick. A four-line zustand store with `localStorage` does both, and — being a store — it's readable from the synthesis code *and* the button:
+
+```ts
+// src/store/useAudio.ts
+export const useAudio = create((set) => ({
+  muted: localStorage.getItem('hadi-3d-muted') === '1',
+  toggleMute: () => set((s) => {
+    const muted = !s.muted
+    localStorage.setItem('hadi-3d-muted', muted ? '1' : '0')
+    return { muted }
+  }),
+}))
+```
+
+`blip()` checks `useAudio.getState().muted` and bails *before* touching the audio context, so muting is instant and total. The button is a 🔊/🔇 pill that nudges on hover — itself a micro-interaction (Step 5).
+
+> ♿ **Default to *on*, but make *off* one tap away and persistent.** A muted-by-default portfolio loses the delight; an un-mutable one loses the visitor. Respect the toggle and remember it.
+
+---
+
+## Step 3 — A Loading Screen Worth the Wait
+
+drei's `useProgress()` hands you `{ progress, active }` for free. The old loader spent it on bare text — `Loading 47%`. The first thing a visitor sees deserves better, and it costs nothing but CSS:
+
+```tsx
+const { progress, active } = useProgress()
+const pct = Math.round(progress)
+
+<Html center>
+  <div /* branded card: gradient, name in gold gradient-text */>
+    Hadi Halim · 3D Portfolio
+    <div /* track */>
+      <div style={{ width: `${pct}%`, transition: 'width 0.25s ease-out',
+                    background: 'linear-gradient(90deg,#ffd27a,#ffb347)' }} />
+    </div>
+    <span>{active ? 'Memuat ruangan…' : 'Hampir siap…'}</span>
+    <span>{pct}%</span>
+  </div>
+</Html>
+```
+
+Two details do the heavy lifting: a `transition: width 0.25s` so the bar **glides** between progress jumps instead of teleporting, and a gentle `@keyframes` pulse on the status text so the screen feels *alive* even when a big GLB stalls the number. The brand name uses gradient-clipped text (`background-clip: text`) — a free touch of premium.
+
+---
+
+## Step 4 — Cinematic Camera Easing
+
+The camera already animates between views (Part 8). `CameraControls` exposes **`smoothTime`** — the seconds it eases toward a target — and we'd been on the snappy default. Bumping it makes every fly-to feel *directed*:
+
+```tsx
+<CameraControls
+  smoothTime={0.5}            // cinematic glide between view presets
+  draggingSmoothTime={0.12}   // but keep manual rotation crisp
+  makeDefault
+/>
+```
+
+The split matters: **slow the scripted transitions, keep the direct manipulation fast.** A 0.5 s glide when you click "Experience" feels expensive and intentional; a 0.5 s lag while you *drag* would feel broken. Different smoothing for different intents.
+
+---
+
+## Step 5 — Micro-Interactions: the 2-Pixel Difference
+
+The smallest changes give the most "feel". Two examples.
+
+**DOM buttons lift on hover.** A 2 px rise and a quick transition turns a flat target into something that responds to your cursor:
+
+```tsx
+onMouseOver={(e) => (e.currentTarget.style.transform = 'translateY(-2px)')}
+onMouseOut={(e)  => (e.currentTarget.style.transform = 'translateY(0)')}
+style={{ transition: 'background 0.2s, color 0.2s, transform 0.15s' }}
+```
+
+**3D objects swell on hover** — but *smoothly*, lerped per-frame, never a snap. The social cubes already track a `hovered` flag for their tooltip; one line in their existing `useFrame` makes them breathe:
+
+```tsx
+useFrame((_, dt) => {
+  ref.current.rotation.y += spin * dt
+  const target = hovered && active ? 1.16 : 1
+  const s = THREE.MathUtils.damp(ref.current.scale.x, target, 10, dt)  // frame-rate-independent
+  ref.current.scale.setScalar(s)
+})
+```
+
+> 🌀 **`THREE.MathUtils.damp`, not `lerp`.** `damp(current, target, lambda, dt)` is the frame-rate-independent cousin of lerp — it eases the same on a 144 Hz monitor and a 30 fps phone. Any time you smooth toward a target in `useFrame`, reach for `damp` and pass `dt`. (And pair the swell with a soft `hover` blip, gated to the focused view so it never becomes noise.)
+
+---
+
+## Lessons Learned in Part 12
+
+- **Synthesize UI sound, don't ship it.** The Web Audio API turns an oscillator + a gain envelope into clicks, whooshes, and opens — kilobytes of code instead of megabytes of MP3.
+- **Pitch direction is language:** sweep up to open, down to close. Ears read it before eyes read the label.
+- **Respect the autoplay rule.** Create/resume the `AudioContext` on the first gesture; let the very first sound drop.
+- **Sound must be mutable *and* sticky** — a tiny persisted store, checked before you make a peep.
+- **A loading screen is your first impression** — brand it, animate the bar's `width`, pulse the status. It's all CSS.
+- **Smooth scripted motion, keep manual motion crisp** — `smoothTime` vs `draggingSmoothTime`.
+- **Micro-interactions are 2 pixels and one line.** Lift DOM buttons on hover; `damp` 3D objects toward a hover scale. Small, smooth, frame-rate-independent.
+
+---
+
+## The End — and What You've Built
+
+Twelve parts ago this was an empty `<Canvas>`. Now it's a **navigable, interactive, fast, mobile-friendly, delightful 3D portfolio**: a room you can tour, a desktop you can click, a résumé you can read, tutorials you can open, lights you can flip — and now, one that *sounds* and *feels* like a finished product.
+
+Everything except the final mile — **deployment** — is done. Put it behind a URL and let it speak for you. Thanks for building the whole thing alongside me. 🏠✨
+
+---
+
+### Asset Credits
+
+- Sound — synthesized at runtime with the [Web Audio API](https://developer.mozilla.org/docs/Web/API/Web_Audio_API) (no files)
+- Loading progress — `useProgress` from [@react-three/drei](https://github.com/pmndrs/drei)
+- State — [zustand](https://github.com/pmndrs/zustand)

--- a/src/audio/sound.ts
+++ b/src/audio/sound.ts
@@ -1,0 +1,73 @@
+// src/audio/sound.ts
+// SFX UI PROSEDURAL via Web Audio API — tanpa file suara. Tiap bunyi = oscillator
+// pendek dengan envelope cepat. Ringan, instan, dan bisa diganti file asli nanti.
+//
+// Catatan autoplay: browser melarang audio sebelum ada interaksi user, jadi
+// AudioContext baru dibuat/di-resume saat pertama kali dibutuhkan (mis. klik).
+
+import { useAudio } from '../store/useAudio'
+
+let ctx: AudioContext | null = null
+
+function getCtx(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+  if (!ctx) {
+    const AC = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AC) return null
+    ctx = new AC()
+  }
+  if (ctx.state === 'suspended') void ctx.resume()
+  return ctx
+}
+
+type Tone = {
+  freq: number
+  dur: number
+  type?: OscillatorType
+  gain?: number
+  /** geser frekuensi (Hz) sepanjang durasi: + naik, - turun */
+  sweep?: number
+}
+
+function blip({ freq, dur, type = 'sine', gain = 0.05, sweep = 0 }: Tone) {
+  if (useAudio.getState().muted) return
+  const ac = getCtx()
+  if (!ac) return
+  const t = ac.currentTime
+  const osc = ac.createOscillator()
+  const g = ac.createGain()
+  osc.type = type
+  osc.frequency.setValueAtTime(freq, t)
+  if (sweep) osc.frequency.exponentialRampToValueAtTime(Math.max(40, freq + sweep), t + dur)
+  // envelope: attack cepat lalu decay halus (hindari klik DC)
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.exponentialRampToValueAtTime(gain, t + 0.01)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+  osc.connect(g).connect(ac.destination)
+  osc.start(t)
+  osc.stop(t + dur + 0.03)
+}
+
+// Dua nada berurutan (mis. untuk "fly"/whoosh yang lebih berisi).
+function chord(a: Tone, b: Tone, delay = 0.04) {
+  blip(a)
+  window.setTimeout(() => blip(b), delay * 1000)
+}
+
+export const sfx = {
+  /** klik tombol UI biasa */
+  click: () => blip({ freq: 430, dur: 0.08, type: 'triangle', gain: 0.045, sweep: 90 }),
+  /** hover lembut (dipakai hemat) */
+  hover: () => blip({ freq: 720, dur: 0.04, type: 'sine', gain: 0.018 }),
+  /** kamera terbang ke area (naik) */
+  whoosh: () => chord({ freq: 240, dur: 0.18, type: 'sine', gain: 0.04, sweep: 360 }, { freq: 480, dur: 0.12, type: 'sine', gain: 0.025, sweep: 200 }),
+  /** buka panel/drawer */
+  open: () => chord({ freq: 360, dur: 0.1, type: 'sine', gain: 0.04, sweep: 180 }, { freq: 560, dur: 0.1, type: 'sine', gain: 0.03, sweep: 160 }),
+  /** tutup/keluar (turun) */
+  close: () => blip({ freq: 480, dur: 0.14, type: 'sine', gain: 0.04, sweep: -260 }),
+}
+
+// Dipanggil sekali dari interaksi user pertama agar AudioContext "hangat".
+export function primeAudio() {
+  getCtx()
+}

--- a/src/components/BookShelf.tsx
+++ b/src/components/BookShelf.tsx
@@ -12,6 +12,7 @@ import type { GLTF } from 'three-stdlib'
 import { useFocus } from '../store/useFocus'
 import { TUTORIALS, type Article } from '../config/tutorials'
 import { openLink } from '../config/links'
+import { sfx, primeAudio } from '../audio/sound'
 
 type BooksGLTF = GLTF & { nodes: { Book: THREE.Mesh; Sheets: THREE.Mesh } }
 
@@ -100,6 +101,8 @@ function CellBooks({ articles, color }: { articles: Article[]; color: string }) 
         const c = base.clone().multiplyScalar(0.7 + (i % 4) * 0.13)
         const open = (e: { stopPropagation: () => void }) => {
           e.stopPropagation()
+          primeAudio()
+          sfx.click()
           openLink(a.url)
         }
         const over = (e: { stopPropagation: () => void }) => {
@@ -214,6 +217,8 @@ export function BookShelf(props: JSX.IntrinsicElements['group']) {
             position={[cx, cy, 0]}
             onClick={(e) => {
               e.stopPropagation()
+              primeAudio()
+              sfx.open()
               openSeries(series)
             }}
             onPointerOver={(e) => {

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,20 +1,81 @@
 // src/components/Loader.tsx
+// Layar loading: kartu elegan dengan judul, progress bar animatif, dan persen.
+// Dirender sebagai fallback <Suspense> (Html, di tengah layar).
 
 import { Html, useProgress } from '@react-three/drei'
 
 export function Loader() {
-  const { progress } = useProgress()
+  const { progress, active } = useProgress()
+  const pct = Math.min(100, Math.round(progress))
 
   return (
     <Html center>
-      <div style={{
-        background: '#222',
-        padding: '10px 20px',
-        borderRadius: '8px',
-        color: 'white',
-        fontFamily: 'sans-serif',
-      }}>
-        Loading... {progress.toFixed(0)}%
+      <div
+        style={{
+          width: 320,
+          maxWidth: '80vw',
+          padding: '26px 28px',
+          borderRadius: 18,
+          background: 'linear-gradient(150deg, #1b2031, #0c0e16)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: '0 24px 70px rgba(0,0,0,0.6)',
+          color: '#fff',
+          fontFamily: 'system-ui, sans-serif',
+          textAlign: 'center',
+          userSelect: 'none',
+        }}
+      >
+        {/* keyframes lokal untuk shimmer & pulse */}
+        <style>
+          {`@keyframes hl-pulse{0%,100%{opacity:.55}50%{opacity:1}}
+            @keyframes hl-shimmer{0%{background-position:-160px 0}100%{background-position:320px 0}}`}
+        </style>
+
+        <div
+          style={{
+            fontSize: 19,
+            fontWeight: 800,
+            letterSpacing: 0.4,
+            background: 'linear-gradient(135deg, #ffe1a3, #ffc24d)',
+            WebkitBackgroundClip: 'text',
+            backgroundClip: 'text',
+            color: 'transparent',
+          }}
+        >
+          Hadi Halim
+        </div>
+        <div style={{ fontSize: 11.5, letterSpacing: 2, color: '#8b93a7', marginTop: 3, textTransform: 'uppercase' }}>
+          3D Portfolio
+        </div>
+
+        {/* track + bar progress */}
+        <div
+          style={{
+            marginTop: 20,
+            height: 7,
+            borderRadius: 999,
+            background: 'rgba(255,255,255,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${pct}%`,
+              height: '100%',
+              borderRadius: 999,
+              background: 'linear-gradient(90deg, #ffd27a, #ffb347)',
+              boxShadow: '0 0 12px rgba(255,194,77,0.6)',
+              transition: 'width 0.25s ease-out',
+            }}
+          />
+        </div>
+
+        <div style={{ marginTop: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12, color: '#aab2c5' }}>
+          <span style={{ animation: 'hl-pulse 1.4s ease-in-out infinite' }}>
+            {active ? 'Memuat ruangan…' : 'Hampir siap…'}
+          </span>
+          <span style={{ fontWeight: 700, color: '#ffd27a' }}>{pct}%</span>
+        </div>
       </div>
     </Html>
   )

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -29,6 +29,7 @@ import { SocialShelf } from './SocialShelf'
 import { BookShelf } from './BookShelf'
 import { Cactus } from './Cactus'
 import { useFocus } from '../store/useFocus'
+import { sfx, primeAudio } from '../audio/sound'
 export const Room = () => {
     const deskScale = 1.5 / 2;
     const doorScale = 2.5 / 2.138395843336184
@@ -37,6 +38,8 @@ export const Room = () => {
     // (interaktivitas di dalam layar komputer akan ditambahkan nanti)
     const deskClick = (e: { stopPropagation: () => void }) => {
         e.stopPropagation()
+        primeAudio()
+        sfx.whoosh()
         setView('desk')
     }
     const pointer = {

--- a/src/components/SocialShelf.tsx
+++ b/src/components/SocialShelf.tsx
@@ -11,6 +11,7 @@ import { Html } from '@react-three/drei'
 import { SVGLoader } from 'three-stdlib'
 import { LINKS, openLink } from '../config/links'
 import { useFocus } from '../store/useFocus'
+import { sfx, primeAudio } from '../audio/sound'
 
 // Path single-path brand (viewBox 24x24).
 const PATHS: Record<string, string> = {
@@ -76,7 +77,12 @@ function LogoCube({ name, label, url, bg, size, spin, position }: CubeProps) {
   ]
 
   useFrame((_, dt) => {
-    if (ref.current) ref.current.rotation.y += spin * dt
+    if (!ref.current) return
+    ref.current.rotation.y += spin * dt
+    // micro-interaction: membesar lembut saat hover (di area Contact)
+    const target = hovered && active ? 1.16 : 1
+    const s = THREE.MathUtils.damp(ref.current.scale.x, target, 10, dt)
+    ref.current.scale.setScalar(s)
   })
 
   return (
@@ -85,6 +91,8 @@ function LogoCube({ name, label, url, bg, size, spin, position }: CubeProps) {
       position={position}
       onClick={(e) => {
         e.stopPropagation()
+        primeAudio()
+        sfx.click()
         openLink(url)
       }}
       onPointerOver={(e) => {
@@ -92,6 +100,7 @@ function LogoCube({ name, label, url, bg, size, spin, position }: CubeProps) {
         e.stopPropagation()
         document.body.style.cursor = 'pointer'
         setHovered(true)
+        sfx.hover()
       }}
       onPointerOut={() => {
         document.body.style.cursor = 'auto'

--- a/src/components/camera/CameraRig.tsx
+++ b/src/components/camera/CameraRig.tsx
@@ -98,5 +98,16 @@ export function CameraRig() {
     c.setLookAt(v.pos[0], v.pos[1], v.pos[2], v.target[0], v.target[1], v.target[2], true)
   }, [view, homeKey])
 
-  return <CameraControls ref={ref} makeDefault minDistance={OVERVIEW_MIN} maxDistance={OVERVIEW_MAX} />
+  // smoothTime lebih besar = perpindahan view terasa sinematik (easing halus);
+  // draggingSmoothTime tetap kecil supaya rotasi manual tetap responsif.
+  return (
+    <CameraControls
+      ref={ref}
+      makeDefault
+      smoothTime={0.5}
+      draggingSmoothTime={0.12}
+      minDistance={OVERVIEW_MIN}
+      maxDistance={OVERVIEW_MAX}
+    />
+  )
 }

--- a/src/components/ui/SceneMenu.tsx
+++ b/src/components/ui/SceneMenu.tsx
@@ -9,6 +9,8 @@ import { useFocus, type ViewName } from '../../store/useFocus'
 import { openLink } from '../../config/links'
 import { TUTORIALS } from '../../config/tutorials'
 import { useIsMobile } from '../../hooks/useMediaQuery'
+import { useAudio } from '../../store/useAudio'
+import { sfx, primeAudio } from '../../audio/sound'
 
 const NAV: { view: ViewName; label: string; icon: string }[] = [
   { view: 'overview', label: 'Beranda', icon: '🏠' },
@@ -98,6 +100,8 @@ export function SceneMenu() {
   const startTour = useFocus((s) => s.startTour)
   const stopTour = useFocus((s) => s.stopTour)
   const reset = useFocus((s) => s.reset)
+  const muted = useAudio((s) => s.muted)
+  const toggleMute = useAudio((s) => s.toggleMute)
 
   const isMobile = useIsMobile()
   const focused = view !== 'overview'
@@ -126,10 +130,18 @@ export function SceneMenu() {
     }
   }, [touring, step, setView, reset])
 
-  const tourNext = () => (step + 1 >= TOUR.length ? reset() : setStep(step + 1))
-  const tourPrev = () => setStep((s) => Math.max(0, s - 1))
+  const tourNext = () => {
+    sfx.click()
+    step + 1 >= TOUR.length ? reset() : setStep(step + 1)
+  }
+  const tourPrev = () => {
+    sfx.click()
+    setStep((s) => Math.max(0, s - 1))
+  }
 
   const onNav = (v: ViewName) => {
+    primeAudio() // hangatkan AudioContext pada interaksi pertama
+    sfx.whoosh() // bunyi kamera terbang ke area
     if (touring) stopTour()
     // klik "Beranda" -> reset() agar kamera selalu kembali ke framing overview
     // yang rapi (homeKey naik), bahkan saat view sudah 'overview' tapi terlanjur
@@ -142,23 +154,50 @@ export function SceneMenu() {
     <>
       {/* Kontrol kiri-atas: Tour */}
       {!focused && !touring && (
-        <button onClick={() => startTour()} style={pill('#7c5cff')}>
+        <button onClick={() => { primeAudio(); sfx.open(); startTour() }} style={pill('#7c5cff')}>
           ▶ Tur Ruangan
         </button>
       )}
 
-      {/* Kontrol kanan-atas: Stop tour / Keluar */}
-      {touring ? (
-        <button onClick={() => reset()} style={{ ...pill('#ff6b6b'), left: 'auto', right: 18 }}>
-          ⏹ Hentikan Tur
-        </button>
-      ) : (
-        focused && (
-          <button onClick={() => reset()} style={{ ...pill('#ffd27a'), left: 'auto', right: 18, color: '#1a1a1a' }}>
+      {/* Kontrol kanan-atas: [Stop/Keluar] + [mute] SEJAJAR dalam satu baris */}
+      <div style={{ position: 'absolute', top: 18, right: 18, zIndex: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
+        {touring && (
+          <button onClick={() => { sfx.close(); reset() }} style={{ ...pill('#ff6b6b'), position: 'static', top: undefined, left: undefined }}>
+            ⏹ Hentikan Tur
+          </button>
+        )}
+        {focused && !touring && (
+          <button onClick={() => { sfx.close(); reset() }} style={{ ...pill('#ffd27a'), position: 'static', top: undefined, left: undefined, color: '#1a1a1a' }}>
             ✕ Keluar
           </button>
-        )
-      )}
+        )}
+        {/* Tombol mute/suara — sejajar dengan tombol Keluar */}
+        <button
+          onClick={() => { primeAudio(); toggleMute(); }}
+          title={muted ? 'Suara: mati' : 'Suara: nyala'}
+          aria-label={muted ? 'Nyalakan suara' : 'Matikan suara'}
+          style={{
+            width: 40,
+            height: 40,
+            padding: 0,
+            flex: 'none',
+            borderRadius: '50%',
+            border: '1px solid rgba(255,255,255,0.18)',
+            cursor: 'pointer',
+            background: 'rgba(20,20,24,0.6)',
+            backdropFilter: 'blur(8px)',
+            color: '#fff',
+            fontSize: 17,
+            lineHeight: 1,
+            boxShadow: '0 4px 14px rgba(0,0,0,0.35)',
+            transition: 'transform 0.15s, background 0.2s',
+          }}
+          onMouseOver={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
+          onMouseOut={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+        >
+          {muted ? '🔇' : '🔊'}
+        </button>
+      </div>
 
       {/* Kartu penjelasan area saat tour berjalan */}
       {touring && (
@@ -254,6 +293,14 @@ export function SceneMenu() {
               onClick={() => onNav(n.view)}
               title={n.label}
               aria-label={n.label}
+              onMouseOver={(e) => {
+                if (!active) e.currentTarget.style.background = 'rgba(255,255,255,0.10)'
+                e.currentTarget.style.transform = 'translateY(-2px)'
+              }}
+              onMouseOut={(e) => {
+                if (!active) e.currentTarget.style.background = 'transparent'
+                e.currentTarget.style.transform = 'translateY(0)'
+              }}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -270,7 +317,7 @@ export function SceneMenu() {
                 color: active ? '#1a1a1a' : '#e8e8e8',
                 background: active ? 'linear-gradient(135deg, #ffe1a3, #ffc24d)' : 'transparent',
                 boxShadow: active ? '0 3px 10px rgba(255,194,77,0.45)' : 'none',
-                transition: 'background 0.2s, color 0.2s',
+                transition: 'background 0.2s, color 0.2s, transform 0.15s',
               }}
             >
               <span style={{ fontSize: isMobile ? 18 : 15, lineHeight: 1 }}>{n.icon}</span>
@@ -283,7 +330,7 @@ export function SceneMenu() {
       {/* Modal foto diperbesar (fancy) */}
       {photo && (
         <div
-          onClick={closePhoto}
+          onClick={() => { sfx.close(); closePhoto() }}
           style={{
             position: 'absolute',
             inset: 0,
@@ -318,7 +365,7 @@ export function SceneMenu() {
             }}
           >
             <button
-              onClick={closePhoto}
+              onClick={() => { sfx.close(); closePhoto() }}
               aria-label="Tutup"
               style={{
                 position: 'absolute',
@@ -381,7 +428,7 @@ export function SceneMenu() {
 
       {/* Drawer daftar artikel series (kiri) */}
       {panel === 'series' && series !== null && TUTORIALS[series] && (
-        <Drawer side="left" title={TUTORIALS[series].name} accent={TUTORIALS[series].color} onClose={closePanel}>
+        <Drawer side="left" title={TUTORIALS[series].name} accent={TUTORIALS[series].color} onClose={() => { sfx.close(); closePanel() }}>
           <p style={{ margin: '0 0 14px', fontSize: 12, color: '#9aa' }}>
             {TUTORIALS[series].articles.length} artikel · klik untuk baca di Medium
           </p>
@@ -389,7 +436,7 @@ export function SceneMenu() {
             {TUTORIALS[series].articles.map((a, i) => (
               <li key={i}>
                 <button
-                  onClick={() => openLink(a.url)}
+                  onClick={() => { sfx.click(); openLink(a.url) }}
                   style={{
                     width: '100%',
                     textAlign: 'left',

--- a/src/store/useAudio.ts
+++ b/src/store/useAudio.ts
@@ -1,0 +1,34 @@
+// src/store/useAudio.ts
+// State suara global (mute) yang dibagikan UI HTML & objek 3D. Pakai zustand
+// (lintas batas Canvas) + persist preferensi ke localStorage.
+
+import { create } from 'zustand'
+
+const KEY = 'hadi-3d-muted'
+
+function readMuted(): boolean {
+  try {
+    return typeof window !== 'undefined' && window.localStorage.getItem(KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+type AudioState = {
+  muted: boolean
+  toggleMute: () => void
+}
+
+export const useAudio = create<AudioState>((set) => ({
+  muted: readMuted(),
+  toggleMute: () =>
+    set((s) => {
+      const muted = !s.muted
+      try {
+        window.localStorage.setItem(KEY, muted ? '1' : '0')
+      } catch {
+        /* abaikan storage error */
+      }
+      return { muted }
+    }),
+}))


### PR DESCRIPTION
## Part 12 — Make It Delightful (series finale)

The polish layer: sound, a real loading screen, cinematic easing, and micro-interactions. No audio files added.

### Audio (procedural, Web Audio API)
- `src/audio/sound.ts` — `blip()` synthesizes every UI sound from an oscillator + exponential gain envelope. `sfx.click / hover / whoosh / open / close`. Pitch sweeps **up** to open, **down** to close.
- AudioContext is created/resumed on the **first gesture** (autoplay policy) via `primeAudio()`.
- `useAudio` store (zustand) — **mute toggle persisted to localStorage**; `blip()` bails when muted.
- Wired to: menu nav (whoosh), tour/drawer/photo (open/close), book & social-cube clicks, cube hover.

### Polish
- **Mute button** in the menu, in a row aligned with the Exit button.
- **Loading screen** ([Loader.tsx](src/components/Loader.tsx)): branded card, gradient title, animated progress bar, pulsing status — replaces the plain "Loading %".
- **Cinematic camera easing**: `CameraControls smoothTime={0.5}` for scripted fly-tos + `draggingSmoothTime={0.12}` so manual rotation stays crisp.
- **Micro-interactions**: nav buttons lift on hover; social cubes `THREE.MathUtils.damp`-scale up on hover (frame-rate-independent).

### Docs
- `docs/part12.md` (full) + `docs/part12-medium.md` (Medium) — series finale.

### Verification
- `tsc -b --noEmit` clean · `vite build` succeeds.

> This completes the "everything except deployment" arc: Parts 9 (interactivity) → 10 (performance) → 11 (mobile) → 12 (polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)