### PR TITLE
docs: complete & harmonize the tutorial series (Part 1-13)

### DIFF
--- a/docs/part1.md
+++ b/docs/part1.md
@@ -234,4 +234,8 @@ You now have a fully interactive 3D scene that includes:
 
 It might look simple right now — but this is the canvas for your future 3D profile website!
 
-Want to try this yourself or explore the code in detail?
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part1` branch](https://github.com/myoxine/3d-profile/tree/part1).

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -6,16 +6,22 @@ In this first part, we're going to create the foundation of your very own intera
 
 Whether you're new to 3D or just want to build a portfolio that actually feels alive, you're in the right place.
 
-## What We'll Do in This Part:
+In this first part, we'll:
 
-- Set up a Vite + React + TypeScript project
-- Install and configure React Three Fiber and Drei
-- Create a basic 3D room (floor, walls, box)
-- Enable orbit camera controls
+- ✅ Set up a Vite + React + TypeScript project
+- ✅ Install and configure React Three Fiber and Drei
+- ✅ Create a basic 3D room (floor, walls, box)
+- ✅ Enable orbit camera controls
 
 ---
 
-## Step 1: Project Setup
+## Why Start With a Simple Room
+
+Before furniture, lighting moods, and clickable interactivity, you need a stage to put them on. A 3D scene is just a few core pieces — a **canvas**, some **lights**, a **camera**, and **meshes** — and the fastest way to understand how they fit together is to build the smallest possible room and orbit around it. Everything in the next twelve parts hangs off this foundation, so we keep it deliberately minimal: get the loop running, see a box cast a shadow, and you're ready to grow it.
+
+---
+
+## Step 1 — Project Setup
 
 Let's create a new Vite project using the React + TypeScript template.
 
@@ -43,7 +49,7 @@ Head over to http://localhost:5173 — your app is live.
 
 ---
 
-## Step 2: Create a 3D Scene with React Three Fiber
+## Step 2 — Create a 3D Scene with React Three Fiber
 
 Let's clean up the homepage and drop in a 3D canvas. Let's update our `App.tsx` to show a simple 3D canvas with some lights and camera controls:
 
@@ -68,7 +74,7 @@ This gives you a 3D canvas with basic lighting and interactive orbit controls.
 
 ---
 
-## Step 3: Add Simple Lighting
+## Step 3 — Add Simple Lighting
 
 Lighting is one of the most important parts of 3D scenes — it helps define shape, depth, and atmosphere.
 
@@ -94,7 +100,7 @@ These two combined give a nice soft light setup, perfect for previewing objects 
 
 ---
 
-## Step 4: Build a Simple Room
+## Step 4 — Build a Simple Room
 
 Now let's create a minimal room — just a floor, some walls, and a box that will later become furniture, a desk, or whatever you want it to be!
 
@@ -161,7 +167,7 @@ export default function App() {
 
 ---
 
-## Step 5: Add Lighting with Shadows
+## Step 5 — Add Lighting with Shadows
 
 So far, we've added some simple lighting. But to make your scene look realistic, you also need **shadows**.
 
@@ -224,19 +230,17 @@ Objects that should show shadows falling onto them need `receiveShadow`:
 
 ---
 
-## What You Have Now
+## Lessons Learned in Part 1
 
-You now have a fully interactive 3D scene that includes:
-
-- ✅ A basic room layout with floor and walls
-- ✅ A floating box in the center (which could become furniture or decor)
-- ✅ Simple lighting and orbit controls so you can explore your scene
-
-It might look simple right now — but this is the canvas for your future 3D profile website!
+- **A 3D scene is four pieces.** A `<Canvas>`, lights, a camera, and meshes — once those click into place, everything else is composition.
+- **`<Canvas shadows>` is opt-in, and so is every shadow.** The renderer, each light (`castShadow`), and each mesh (`castShadow` / `receiveShadow`) must all agree before a shadow appears.
+- **Two lights go a long way.** A soft `ambientLight` keeps nothing pure-black; a `directionalLight` gives shape and a sun-like shadow.
+- **`OrbitControls` is the fastest way to *see* your scene** while you build — we'll trade it for animated camera moves much later (Part 8).
+- It looks simple now, but this minimal room is the canvas for your future 3D profile website.
 
 ---
 
-## 🚀 What's Next (Part 2)
+## What's Next (Part 2)
 
 Right now everything is flat color and a floating box. In the next part we give the room some soul:
 
@@ -246,6 +250,13 @@ Right now everything is flat color and a floating box. In the next part we give 
 - 🛠️ Rebuilding the room out of reusable components
 
 Stay tuned — your cardboard box is about to become a real space!
+
+---
+
+## Asset Credits
+
+- No external assets yet — Part 1 is pure geometry and lights.
+- Built with [React Three Fiber](https://r3f.docs.pmnd.rs/), [drei](https://github.com/pmndrs/drei), and [Vite](https://vite.dev/).
 
 ---
 

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -236,6 +236,19 @@ It might look simple right now — but this is the canvas for your future 3D pro
 
 ---
 
+## 🚀 What's Next (Part 2)
+
+Right now everything is flat color and a floating box. In the next part we give the room some soul:
+
+- 🪵 **Realistic textures** on the floor and walls (color, roughness, normal, AO maps)
+- 🧱 **Walls with holes** for windows and doors, built with `ExtrudeGeometry`
+- 🪟 A **reflective glass window** with a frame
+- 🛠️ Rebuilding the room out of reusable components
+
+Stay tuned — your cardboard box is about to become a real space!
+
+---
+
 ## 📦 Full Source Code
 
 👉 Explore the complete code for this part on the [`part1` branch](https://github.com/myoxine/3d-profile/tree/part1).

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -1,0 +1,237 @@
+# 3D Profile Website - Part 1: Set Up & Build Your First 3D Room with React Three Fiber
+
+Welcome to the **3D Profile Website** tutorial series!
+
+In this first part, we're going to create the foundation of your very own interactive 3D website — starting with a simple but stylish virtual room using **React Three Fiber** (a React renderer for Three.js) and **Vite** for blazing fast development.
+
+Whether you're new to 3D or just want to build a portfolio that actually feels alive, you're in the right place.
+
+## What We'll Do in This Part:
+
+- Set up a Vite + React + TypeScript project
+- Install and configure React Three Fiber and Drei
+- Create a basic 3D room (floor, walls, box)
+- Enable orbit camera controls
+
+---
+
+## Step 1: Project Setup
+
+Let's create a new Vite project using the React + TypeScript template.
+
+Open your terminal and run:
+
+```bash
+npm create vite@latest 3d-profile --template react-ts
+cd 3d-profile
+npm install
+```
+
+Now, install the 3D libraries we'll need:
+
+```bash
+npm install three @react-three/fiber @react-three/drei
+```
+
+Then start the dev server:
+
+```bash
+npm run dev
+```
+
+Head over to http://localhost:5173 — your app is live.
+
+---
+
+## Step 2: Create a 3D Scene with React Three Fiber
+
+Let's clean up the homepage and drop in a 3D canvas. Let's update our `App.tsx` to show a simple 3D canvas with some lights and camera controls:
+
+```tsx
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+
+export default function App() {
+  return (
+    <div style={{ width: "100vw", height: "100vh" }}>
+      <Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+        <ambientLight intensity={1} />
+        <directionalLight position={[0, 2, 3]} intensity={1} />
+        <OrbitControls />
+      </Canvas>
+    </div>
+  );
+}
+```
+
+This gives you a 3D canvas with basic lighting and interactive orbit controls.
+
+---
+
+## Step 3: Add Simple Lighting
+
+Lighting is one of the most important parts of 3D scenes — it helps define shape, depth, and atmosphere.
+
+In this setup, we use two basic types of lights:
+
+### ambientLight
+
+A soft, global light that lights up everything equally. It keeps your scene from being completely dark.
+
+```tsx
+<ambientLight intensity={0.5} />
+```
+
+### directionalLight
+
+A light that acts like sunlight, shining in a specific direction. Great for creating shadows and highlights.
+
+```tsx
+<directionalLight position={[0, 2, 3]} intensity={1} />
+```
+
+These two combined give a nice soft light setup, perfect for previewing objects in a neutral environment.
+
+---
+
+## Step 4: Build a Simple Room
+
+Now let's create a minimal room — just a floor, some walls, and a box that will later become furniture, a desk, or whatever you want it to be!
+
+Create a new component:
+
+```tsx
+export const Room = () => {
+  return (
+    <>
+      {/* Floor */}
+      <mesh position={[0, 0.05, 0]} receiveShadow>
+        <boxGeometry args={[3, 0.1, 3]} />
+        <meshStandardMaterial color="#ffffff" />
+      </mesh>
+
+      {/* Back Wall */}
+      <mesh position={[0, 2, -1.55]} receiveShadow>
+        <boxGeometry args={[3, 4, 0.1]} />
+        <meshStandardMaterial color="#ffffff" />
+      </mesh>
+
+      {/* Left Wall */}
+      <mesh position={[-1.55, 2, -0.05]} receiveShadow>
+        <boxGeometry args={[0.1, 4, 3.1]} />
+        <meshStandardMaterial color="#ffffff" />
+      </mesh>
+
+      {/* Right Wall */}
+      <mesh position={[1.55, 2, -0.05]} receiveShadow>
+        <boxGeometry args={[0.1, 4, 3.1]} />
+        <meshStandardMaterial color="#ffffff" />
+      </mesh>
+
+      {/* A Box (Maybe a chair or table?) */}
+      <mesh position={[0, 0.55, 0]} castShadow>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="red" />
+      </mesh>
+    </>
+  );
+};
+```
+
+Then import and use it inside `App.tsx`:
+
+```tsx
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { Room } from './components/Room';
+
+export default function App() {
+  return (
+    <div style={{ width: "100vw", height: "100vh" }}>
+      <Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+        <ambientLight intensity={1} />
+        <directionalLight position={[0, 2, 3]} intensity={1} castShadow />
+        <OrbitControls />
+        <Room />
+      </Canvas>
+    </div>
+  );
+}
+```
+
+---
+
+## Step 5: Add Lighting with Shadows
+
+So far, we've added some simple lighting. But to make your scene look realistic, you also need **shadows**.
+
+Shadows are what give your 3D objects a sense of depth and weight. Without them, everything looks like it's floating in space!
+
+Here's how to add lighting with shadows in React Three Fiber.
+
+### 1. Enable Shadows in the Canvas
+
+First, you need to tell your `<Canvas />` to support shadows. Update your Canvas like this:
+
+```tsx
+<Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+  ...
+</Canvas>
+```
+
+### 2. Configure the Light to Cast Shadows
+
+Next, your light source must be able to cast shadows. For example, with a directional light:
+
+```tsx
+<directionalLight
+  position={[0, 2, 3]}
+  intensity={1}
+  castShadow
+  shadow-mapSize-width={1024}
+  shadow-mapSize-height={1024}
+  shadow-camera-far={20}
+  shadow-camera-left={-10}
+  shadow-camera-right={10}
+  shadow-camera-top={10}
+  shadow-camera-bottom={-10}
+/>
+```
+
+- `castShadow` → tells the light to generate shadows.
+- `shadow-mapSize` → controls shadow quality (higher = sharper shadows).
+- The camera bounds define the area where shadows will appear.
+
+### 3. Set Objects to Cast or Receive Shadows
+
+Objects that cast shadows must have `castShadow` set to true:
+
+```tsx
+<mesh castShadow position={[0, 0.55, 0]}>
+  <boxGeometry args={[1, 1, 1]} />
+  <meshStandardMaterial color="orange" />
+</mesh>
+```
+
+Objects that should show shadows falling onto them need `receiveShadow`:
+
+```tsx
+<mesh receiveShadow position={[0, 0, 0]}>
+  <boxGeometry args={[10, 0.1, 10]} />
+  <meshStandardMaterial color="#ffffff" />
+</mesh>
+```
+
+---
+
+## What You Have Now
+
+You now have a fully interactive 3D scene that includes:
+
+- ✅ A basic room layout with floor and walls
+- ✅ A floating box in the center (which could become furniture or decor)
+- ✅ Simple lighting and orbit controls so you can explore your scene
+
+It might look simple right now — but this is the canvas for your future 3D profile website!
+
+Want to try this yourself or explore the code in detail?

--- a/docs/part10.md
+++ b/docs/part10.md
@@ -251,7 +251,7 @@ Thanks for following along — go put your room on a diet, *carefully*. ⚡
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Geometry compression — [glTF-Transform](https://gltf-transform.dev/) · [Draco](https://github.com/google/draco)
 - HDRI resize — [OpenCV](https://opencv.org/) · original HDRI from [Poly Haven](https://polyhaven.com/)

--- a/docs/part10.md
+++ b/docs/part10.md
@@ -243,7 +243,7 @@ Could we go smaller? Yes — meshopt or aggressive Draco would get the avatars t
 
 ---
 
-## What's Next
+## What's Next (Part 11)
 
 The portfolio is now a quarter of its weight and every model is intact. That sets up **Part 11 — Mobile & Responsive**: touch controls, a menu that reflows on small screens, and a quality tier for weaker GPUs. After that, **Part 12 — Audio & Polish**.
 

--- a/docs/part10.md
+++ b/docs/part10.md
@@ -256,3 +256,9 @@ Thanks for following along — go put your room on a diet, *carefully*. ⚡
 - Geometry compression — [glTF-Transform](https://gltf-transform.dev/) · [Draco](https://github.com/google/draco)
 - HDRI resize — [OpenCV](https://opencv.org/) · original HDRI from [Poly Haven](https://polyhaven.com/)
 - Avatars — [Ready Player Me](https://readyplayer.me/)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part10` branch](https://github.com/myoxine/3d-profile/tree/part10).

--- a/docs/part11.md
+++ b/docs/part11.md
@@ -173,7 +173,7 @@ Good news: almost nothing to do. drei's **`CameraControls` is touch-native** —
 
 ---
 
-## What's Next
+## What's Next (Part 12)
 
 The portfolio now adapts from desktop to a phone in portrait: it renders within budget, frames correctly, and the menu fits a thumb. That leaves the fun finishing touches for **Part 12 — Audio & Polish**: ambient room tone and click SFX, smoother camera easing, a friendlier loading screen, and a few small delights. After that, it's a portfolio you can confidently drop into a résumé link.
 

--- a/docs/part11.md
+++ b/docs/part11.md
@@ -185,3 +185,9 @@ Thanks for following along — go shrink your room to pocket size. 📱
 
 - Camera controls — [`camera-controls`](https://github.com/yomotsu/camera-controls) via [@react-three/drei](https://github.com/pmndrs/drei)
 - Responsive signal — the platform's own [`window.matchMedia`](https://developer.mozilla.org/docs/Web/API/Window/matchMedia)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part11` branch](https://github.com/myoxine/3d-profile/tree/part11).

--- a/docs/part11.md
+++ b/docs/part11.md
@@ -181,7 +181,7 @@ Thanks for following along — go shrink your room to pocket size. 📱
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Camera controls — [`camera-controls`](https://github.com/yomotsu/camera-controls) via [@react-three/drei](https://github.com/pmndrs/drei)
 - Responsive signal — the platform's own [`window.matchMedia`](https://developer.mozilla.org/docs/Web/API/Window/matchMedia)

--- a/docs/part12.md
+++ b/docs/part12.md
@@ -1,6 +1,6 @@
 # 3D Profile Website - Part 12: Make It Delightful — Procedural Audio, a Real Loading Screen & Micro-Interactions
 
-Welcome back — and this is the **finale** of the 3D Profile Website series!
+Welcome back — and this is the **last build part** of the 3D Profile Website series! (One short part remains after this: shipping it online.)
 
 The room is fast (Part 10), works on a phone (Part 11), and every model is intact. What's left is the layer that separates "a demo" from "a *product*": the little touches you don't consciously notice but absolutely feel. In **Part 12** we add the polish:
 
@@ -186,7 +186,19 @@ useFrame((_, dt) => {
 
 Twelve parts ago this was an empty `<Canvas>`. Now it's a **navigable, interactive, fast, mobile-friendly, delightful 3D portfolio**: a room you can tour, a desktop you can click, a résumé you can read, tutorials you can open, lights you can flip — and now, one that *sounds* and *feels* like a finished product.
 
-Everything except the final mile — **deployment** — is done. Put it behind a URL and let it speak for you. Thanks for building the whole thing alongside me. 🏠✨
+Everything except the final mile — **deployment** — is done. That's exactly what we tackle next.
+
+---
+
+## What's Next (Part 13)
+
+The room looks, works, sounds, and feels finished. All that's left is to put it **online** — the focus of **Part 13**:
+
+- 📦 A **production build** and deploying the static SPA (to Vercel)
+- ⚡ **Cache headers** so the 40 MB of 3D assets load instantly on return visits
+- 🔎 **SEO & social meta** — Open Graph, Twitter Card, a real 1200×630 share image, favicon, and a web manifest
+
+Put it behind a URL and let it speak for you — see you in the finale. 🏠✨
 
 ---
 

--- a/docs/part12.md
+++ b/docs/part12.md
@@ -14,6 +14,12 @@ None of this is hard. All of it matters. Let's finish strong.
 
 ---
 
+## Why Polish Matters
+
+The room already works — so why spend a whole part on sounds, easing curves, and 2-pixel hover lifts? Because *working* and *feeling finished* are different things. Polish is the layer a visitor never consciously notices but absolutely feels: a click that responds, a view that glides instead of snapping, a loading screen that looks designed. It's the difference between "a cool demo someone built" and "a product." None of it is technically hard; all of it is what makes the portfolio memorable.
+
+---
+
 ## Step 1 — Sound With No Sound Files
 
 Audio is the fastest way to make an interface feel *alive* — and the fastest way to bloat your bundle with megabytes of MP3s. We skip the files entirely: the **Web Audio API** can *synthesize* every UI sound from an oscillator and a gain envelope. A click is just a short tone with a fast attack and decay.
@@ -182,7 +188,7 @@ useFrame((_, dt) => {
 
 ---
 
-## The End — and What You've Built
+## What You've Built So Far
 
 Twelve parts ago this was an empty `<Canvas>`. Now it's a **navigable, interactive, fast, mobile-friendly, delightful 3D portfolio**: a room you can tour, a desktop you can click, a résumé you can read, tutorials you can open, lights you can flip — and now, one that *sounds* and *feels* like a finished product.
 
@@ -202,7 +208,7 @@ Put it behind a URL and let it speak for you — see you in the finale. 🏠✨
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Sound — synthesized at runtime with the [Web Audio API](https://developer.mozilla.org/docs/Web/API/Web_Audio_API) (no files)
 - Loading progress — `useProgress` from [@react-three/drei](https://github.com/pmndrs/drei)

--- a/docs/part12.md
+++ b/docs/part12.md
@@ -195,3 +195,9 @@ Everything except the final mile — **deployment** — is done. Put it behind a
 - Sound — synthesized at runtime with the [Web Audio API](https://developer.mozilla.org/docs/Web/API/Web_Audio_API) (no files)
 - Loading progress — `useProgress` from [@react-three/drei](https://github.com/pmndrs/drei)
 - State — [zustand](https://github.com/pmndrs/zustand)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part12` branch](https://github.com/myoxine/3d-profile/tree/part12).

--- a/docs/part13.md
+++ b/docs/part13.md
@@ -228,3 +228,9 @@ That's the series. From a black screen to a room with the lights on, behind a do
 - OG image — generated as a 1200×630 card (gradient + gold title)
 - Icons & favicon — custom "H" monogram (SVG + PNG)
 - SEO testing — [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/), [opengraph.xyz](https://www.opengraph.xyz/)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part13` branch](https://github.com/myoxine/3d-profile/tree/part13).

--- a/docs/part13.md
+++ b/docs/part13.md
@@ -14,6 +14,12 @@ A portfolio nobody can open is a private art project. In **Part 13** we put the 
 
 ---
 
+## Why Shipping Matters
+
+Twelve parts of work live on `localhost` — which means, to everyone but you, they don't exist yet. A portfolio's entire job is to be *seen*: opened from a résumé link, shared in a DM, skimmed by a recruiter on their phone. That makes deployment not an afterthought but the part that finally connects the work to an audience — and the share-preview metadata is what decides whether that link looks like a polished product or a broken thumbnail. This part closes the gap between "it runs on my machine" and "anyone, anywhere, can walk through it."
+
+---
+
 ## Step 1 — What `npm run build` Really Produces
 
 Our `build` script is `tsc -b && vite build`: type-check the whole project, then bundle. The output lands in `dist/` — a fully static folder. No Node server, no runtime. That's the whole point: a 3D portfolio is just files a CDN can serve.
@@ -222,7 +228,7 @@ That's the series. From a black screen to a room with the lights on, behind a do
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Hosting — [Vercel](https://vercel.com) (static, CDN, custom domains)
 - OG image — generated as a 1200×630 card (gradient + gold title)

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -401,19 +401,17 @@ export const Room = () => {
 
 ---
 
-## 🎉 What You Have Now
+## Lessons Learned in Part 2
 
-- ✅ A realistic wooden floor
-- ✅ Plaster walls that look like real architecture
-- ✅ Walls with customizable holes for doors or windows
-- ✅ A reflective window with frame
-- ✅ A modern 3D room that's ready to be expanded
-
-Your scene has officially transformed from a blank white box into a beautiful virtual room — the perfect foundation for your interactive 3D profile website.
+- **Textures, not flat colors, sell realism.** A PBR material reads a stack of maps — color, roughness, normal, displacement, AO — and each one does a specific job.
+- **`RepeatWrapping` + `repeat.set()` tile a texture** across a large surface instead of stretching it; tune the repeat to the real-world plank/tile size.
+- **Holes are subtracted geometry.** A wall is a `THREE.Shape`; a window or door is a `THREE.Path` pushed into `shape.holes`, then `ExtrudeGeometry` gives it thickness.
+- **Reusable components keep the scene clean.** `Floor`, `Wall`, and `Window` take props — the room is assembled by composition, not copy-paste meshes.
+- Your scene has officially transformed from a blank white box into a beautiful virtual room — the perfect foundation for the rest of the series.
 
 ---
 
-## 🚀 What's Next (Part 3)
+## What's Next (Part 3)
 
 In the next part, we'll take this even further:
 
@@ -425,8 +423,14 @@ Stay tuned — your 3D profile is about to come to life!
 
 ---
 
-## 📦 Get the Source Code
+## Asset Credits
 
-Want to explore the full working project or customize it yourself?
+- **Wood floor texture** — [WoodFloor039](https://ambientcg.com/) (ambientCG, CC0)
+- **Plaster wall texture** — [Plaster001](https://ambientcg.com/) (ambientCG, CC0)
+- Built with [React Three Fiber](https://r3f.docs.pmnd.rs/) and [drei](https://github.com/pmndrs/drei)
+
+---
+
+## 📦 Full Source Code
 
 👉 Explore the complete code for this part on the [`part2` branch](https://github.com/myoxine/3d-profile/tree/part2).

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -429,4 +429,4 @@ Stay tuned — your 3D profile is about to come to life!
 
 Want to explore the full working project or customize it yourself?
 
-👉 Check out the source code on GitHub: https://github.com/myoxine/3d-profile/tree/part2
+👉 Explore the complete code for this part on the [`part2` branch](https://github.com/myoxine/3d-profile/tree/part2).

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -52,8 +52,10 @@ For this tutorial, we'll use two free 3D assets:
 public/
   models/
     Adjustable Desk.glb
-    Gaming Chair.glb
+    gaming chair.glb
 ```
+
+> ⚠️ **Mind the filename case.** We load this model as `/models/gaming chair.glb` (lowercase). Windows treats `Gaming Chair.glb` and `gaming chair.glb` as the same file, but Linux hosts (Vercel, Netlify, GitHub Pages) are **case-sensitive** — a capitalized filename that works locally will 404 in production. Keep the file and the `useGLTF(...)` path identical.
 
 If your models come with texture images (like JPG or PNG files), copy those into the same `public/models` folder. This way, your app can easily load and display the textures when rendering the models.
 
@@ -151,21 +153,23 @@ import * as THREE from 'three'
 import { useMemo, useRef } from 'react'
 import { Mesh } from 'three'
 import { useTexture } from '@react-three/drei'
+import type { JSX } from 'react'
 
-export interface WallProps {
-  position?: [number, number, number]
+// Wall extends the standard <group> props, so position / rotation / scale
+// all work like any other R3F object. (We intentionally do NOT add a custom
+// `rotationY` prop — rotating via the group's `rotation` prop keeps the API
+// consistent with the rest of the scene.)
+export type WallProps = JSX.IntrinsicElements['group'] & {
   wallSize?: [number, number]
   holeSize?: [number, number]
   holePosition?: [number, number]
-  rotationY?: number
 }
 
 export const Wall = ({
-  position = [0, 0, 0],
   wallSize = [10, 5],
   holeSize,
   holePosition = [0, 0],
-  rotationY = 0
+  ...props
 }: WallProps) => {
   const meshRef = useRef<Mesh>(null!)
 
@@ -222,23 +226,23 @@ export const Wall = ({
   })
 
   return (
-    <mesh
-      ref={meshRef}
-      geometry={wallGeometry}
-      position={position}
-      rotation-y={rotationY}
-      receiveShadow
-      castShadow
-    >
-      <meshStandardMaterial
-        map={colorMap}
-        roughnessMap={roughnessMap}
-        normalMap={normalMap}
-        displacementMap={displacementMap}
-        displacementScale={0}
-        color={'white'}
-      />
-    </mesh>
+    <group {...props} dispose={null}>
+      <mesh
+        ref={meshRef}
+        geometry={wallGeometry}
+        receiveShadow
+        castShadow
+      >
+        <meshStandardMaterial
+          map={colorMap}
+          roughnessMap={roughnessMap}
+          normalMap={normalMap}
+          displacementMap={displacementMap}
+          displacementScale={0}
+          color={'white'}
+        />
+      </mesh>
+    </group>
   )
 }
 ```
@@ -374,11 +378,11 @@ export const Room = () => {
       <Wall
         wallSize={[3.1, 4]}
         position={[1.5, 0, -0.05]}
-        rotationY={0.5 * Math.PI}
+        rotation={[0, 0.5 * Math.PI, 0]}
         holePosition={[0.5, 0]}
         holeSize={[1.1, 1.6]}
       />
-      <Wall wallSize={[3.1, 4]} position={[-1.5, 0, -0.05]} rotationY={0.5 * Math.PI} />
+      <Wall wallSize={[3.1, 4]} position={[-1.5, 0, -0.05]} rotation={[0, 0.5 * Math.PI, 0]} />
       <Window
         width={1}
         height={1.5}

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -1,0 +1,428 @@
+# 3D Profile Website - Part 2: Textures, Walls with Holes, and a Shiny Window
+
+Welcome back to our **3D Profile Website** tutorial!
+
+In Part 1, we built a basic 3D room using React Three Fiber: white walls, a floor, a floating red box, and some lights. Cool… but let's be honest — it still looked like a cardboard box floating in space.
+
+Now, it's time to give it some soul.
+
+In this part, you'll learn how to:
+
+- ✅ Add realistic textures to your floor and walls
+- ✅ Create walls with holes for windows or doors
+- ✅ Model a cool window with reflective glass
+- ✅ Rebuild the room using your new components
+
+By the end, you'll have a room that looks way closer to real life.
+
+Let's dive in!
+
+---
+
+## ✨ Why Textures Matter
+
+So far, all our objects are just flat colors.
+
+Real-life surfaces aren't perfectly flat or evenly colored. Wood planks have grains, plaster walls have bumps, glass reflects light… This is where textures come in.
+
+Types of textures you'll often use:
+
+- **Color (Diffuse) Map** → the photo-realistic color detail of a surface.
+- **Roughness Map** → how shiny or matte the surface looks. Black = shiny, white = matte.
+- **Normal Map** → fakes small surface bumps so light behaves realistically.
+- **Displacement Map** → physically pushes geometry in or out (like real bumps).
+- **Ambient Occlusion Map (AO)** → simulates small shadowy crevices and details.
+
+We'll use these to transform our boring white room into a photorealistic space.
+
+---
+
+## Step 1 — Download Your Textures
+
+Let's bring your 3D scene to life with some awesome models!
+
+For this tutorial, we'll use two free 3D assets:
+
+- **Desk:** Adjustable Desk from Poly Pizza
+- **Chair:** Gaming Chair from Free3D
+
+✅ Download the GLB files for both objects and save them in your project under:
+
+```
+public/
+  models/
+    Adjustable Desk.glb
+    Gaming Chair.glb
+```
+
+If your models come with texture images (like JPG or PNG files), copy those into the same `public/models` folder. This way, your app can easily load and display the textures when rendering the models.
+
+Now you're ready to load these models into your 3D scene!
+
+---
+
+## Step 2 — Create a Textured Floor Component
+
+Let's turn our white floor into beautiful wood. Create a new component:
+
+```tsx
+// src/components/Floor.tsx
+
+import { useTexture } from '@react-three/drei'
+import * as THREE from 'three'
+
+interface FloorProps {
+  position?: [number, number, number]
+  size?: [number, number, number]
+}
+
+export const Floor = ({
+  position = [0, 0.05, 0],
+  size = [3, 0.1, 3]
+}: FloorProps) => {
+  const [
+    colorMap,
+    roughnessMap,
+    normalMap,
+    displacementMap,
+    aoMap
+  ] = useTexture([
+    '/textures/WoodFloor039_1K-JPG_Color.jpg',
+    '/textures/WoodFloor039_1K-JPG_Roughness.jpg',
+    '/textures/WoodFloor039_1K-JPG_NormalGL.jpg',
+    '/textures/WoodFloor039_1K-JPG_Displacement.jpg',
+    '/textures/WoodFloor039_1K-JPG_AmbientOcclusion.jpg'
+  ])
+
+  ;[
+    colorMap,
+    roughnessMap,
+    normalMap,
+    displacementMap,
+    aoMap
+  ].forEach(tex => {
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping
+    tex.repeat.set(1, 1)
+  })
+
+  return (
+    <mesh position={position} receiveShadow>
+      <boxGeometry args={size} />
+      <meshStandardMaterial
+        map={colorMap}
+        roughnessMap={roughnessMap}
+        normalMap={normalMap}
+        displacementMap={displacementMap}
+        displacementScale={0}
+        aoMap={aoMap}
+      />
+    </mesh>
+  )
+}
+```
+
+### How This Works:
+
+- `useTexture` → loads multiple images as textures.
+- `RepeatWrapping` → lets the texture tile over big surfaces rather than stretching.
+- `repeat.set(1, 1)` → how many times the texture repeats across the mesh surface.
+- `meshStandardMaterial` → modern physically-based shading that works great with textures.
+
+> 💡 **Tip:** Try increasing repeat to `(4, 4)` if you want smaller wooden planks.
+
+---
+
+## Step 3 — Create Walls with Optional Holes
+
+A real room has windows and doors. Let's make a wall that can optionally cut holes into itself.
+
+What's the trick? We'll:
+
+1. Define the wall as a large rectangle shape.
+2. Define holes as smaller rectangles.
+3. Subtract holes from the wall shape using Three.js's powerful shape tools.
+4. Extrude the shape into 3D.
+
+Here's the code:
+
+```tsx
+// src/components/Wall.tsx
+import * as THREE from 'three'
+import { useMemo, useRef } from 'react'
+import { Mesh } from 'three'
+import { useTexture } from '@react-three/drei'
+
+export interface WallProps {
+  position?: [number, number, number]
+  wallSize?: [number, number]
+  holeSize?: [number, number]
+  holePosition?: [number, number]
+  rotationY?: number
+}
+
+export const Wall = ({
+  position = [0, 0, 0],
+  wallSize = [10, 5],
+  holeSize,
+  holePosition = [0, 0],
+  rotationY = 0
+}: WallProps) => {
+  const meshRef = useRef<Mesh>(null!)
+
+  const wallGeometry = useMemo(() => {
+    const [wallWidth, wallHeight] = wallSize
+
+    // Define outer rectangle
+    const shape = new THREE.Shape()
+    shape.moveTo(-wallWidth / 2, -wallHeight / 2)
+    shape.lineTo(wallWidth / 2, -wallHeight / 2)
+    shape.lineTo(wallWidth / 2, wallHeight / 2)
+    shape.lineTo(-wallWidth / 2, wallHeight / 2)
+    shape.lineTo(-wallWidth / 2, -wallHeight / 2)
+
+    // Optionally subtract a hole
+    if (holeSize) {
+      const [holeWidth, holeHeight] = holeSize
+      const [holeX, holeY] = holePosition
+
+      const hole = new THREE.Path()
+      hole.moveTo(holeX - holeWidth / 2, holeY - holeHeight / 2)
+      hole.lineTo(holeX + holeWidth / 2, holeY - holeHeight / 2)
+      hole.lineTo(holeX + holeWidth / 2, holeY + holeHeight / 2)
+      hole.lineTo(holeX - holeWidth / 2, holeY + holeHeight / 2)
+      hole.lineTo(holeX - holeWidth / 2, holeY - holeHeight / 2)
+
+      shape.holes.push(hole)
+    }
+
+    const extrudeSettings = {
+      depth: 0.1,
+      bevelEnabled: false
+    }
+
+    return new THREE.ExtrudeGeometry(shape, extrudeSettings)
+  }, [wallSize, holeSize, holePosition])
+
+  // Load plaster textures
+  const [colorMap, roughnessMap, normalMap, displacementMap] = useTexture([
+    '/textures/Plaster001_1K-JPG_Color.jpg',
+    '/textures/Plaster001_1K-JPG_Roughness.jpg',
+    '/textures/Plaster001_1K-JPG_NormalGL.jpg',
+    '/textures/Plaster001_1K-JPG_Displacement.jpg'
+  ])
+
+  ;[
+    colorMap,
+    roughnessMap,
+    normalMap,
+    displacementMap
+  ].forEach(tex => {
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping
+    tex.repeat.set(0.2, 0.2)
+  })
+
+  return (
+    <mesh
+      ref={meshRef}
+      geometry={wallGeometry}
+      position={position}
+      rotation-y={rotationY}
+      receiveShadow
+      castShadow
+    >
+      <meshStandardMaterial
+        map={colorMap}
+        roughnessMap={roughnessMap}
+        normalMap={normalMap}
+        displacementMap={displacementMap}
+        displacementScale={0}
+        color={'white'}
+      />
+    </mesh>
+  )
+}
+```
+
+### How This Works:
+
+- We create a `THREE.Shape` for the wall rectangle.
+- We create `THREE.Path` for the hole and subtract it.
+- `ExtrudeGeometry` gives our wall thickness.
+- Textures make the wall look like real plaster.
+
+> 💡 **Try this:** comment out the hole code and watch your window disappear!
+
+---
+
+## Step 4 — Create a Reflective Window
+
+A hole in a wall is just… a hole. Let's add glass!
+
+Let's build a window with:
+
+- a simple frame
+- a reflective glass surface
+
+Here's our component:
+
+```tsx
+// src/components/Window.tsx
+import React from 'react'
+import type { ThreeElements } from '@react-three/fiber'
+import { MeshReflectorMaterial } from '@react-three/drei'
+
+type GroupProps = ThreeElements['group']
+
+export interface WindowProps extends GroupProps {
+  width?: number
+  height?: number
+  frameThickness?: number
+}
+
+export const Window: React.FC<WindowProps> = ({
+  width = 1,
+  height = 1,
+  frameThickness = 0.05,
+  ...props
+}) => {
+  return (
+    <group {...props}>
+      {/* Top, bottom, and sides of the frame */}
+      <mesh position={[0, 0, 0]}>
+        <boxGeometry args={[width + frameThickness * 2, frameThickness, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+      <mesh position={[0, (height + frameThickness) / 2, 0]}>
+        <boxGeometry args={[width + frameThickness * 2, frameThickness, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+      <mesh position={[0, -(height + frameThickness) / 2, 0]}>
+        <boxGeometry args={[width + frameThickness * 2, frameThickness, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+      <mesh position={[0, 0, 0]}>
+        <boxGeometry args={[frameThickness, height, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+      <mesh position={[(width + frameThickness) / 2, 0, 0]}>
+        <boxGeometry args={[frameThickness, height, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+      <mesh position={[(-width - frameThickness) / 2, 0, 0]}>
+        <boxGeometry args={[frameThickness, height, frameThickness]} />
+        <meshStandardMaterial color={'#444444'} />
+      </mesh>
+
+      {/* Glass pane */}
+      <mesh>
+        <planeGeometry args={[width, height]} />
+        <MeshReflectorMaterial
+          color={'#ffffff'}
+          opacity={0.5}
+          transparent
+          mirror={0.5}
+          distortion={1}
+          reflectorOffset={0.2}
+        />
+      </mesh>
+      <mesh rotation={[0, Math.PI, 0]}>
+        <planeGeometry args={[width, height]} />
+        <MeshReflectorMaterial
+          color={'#ffffff'}
+          opacity={0.8}
+          transparent
+          mirror={0.5}
+          distortion={1}
+          reflectorOffset={0.2}
+        />
+      </mesh>
+    </group>
+  )
+}
+```
+
+### How This Works:
+
+- We create a frame out of several small boxes.
+- The `MeshReflectorMaterial` from drei adds beautiful reflections.
+- Two panes are rendered facing opposite directions so the window looks right from both sides.
+
+✅ Try tweaking:
+
+- `mirror`
+- `opacity`
+- `distortion`
+
+…for cool glass effects!
+
+---
+
+## Step 5 — Put It All Together
+
+Finally, let's assemble our room. Update your `Room` component:
+
+```tsx
+import { Floor } from './Floor'
+import { Wall } from './Wall'
+import { Window } from './Window'
+
+export const Room = () => {
+  return (
+    <>
+      <Floor position={[0, -2 + 0.05, 0]} />
+      <Wall wallSize={[3, 4]} position={[0, 0, -1.6]} />
+      <Wall
+        wallSize={[3.1, 4]}
+        position={[1.5, 0, -0.05]}
+        rotationY={0.5 * Math.PI}
+        holePosition={[0.5, 0]}
+        holeSize={[1.1, 1.6]}
+      />
+      <Wall wallSize={[3.1, 4]} position={[-1.5, 0, -0.05]} rotationY={0.5 * Math.PI} />
+      <Window
+        width={1}
+        height={1.5}
+        frameThickness={0.05}
+        position={[1.55, 0, -0.55]}
+        rotation={[0, 0.5 * Math.PI, 0]}
+      />
+      <mesh position={[0, -1 + 0.1, -1]} castShadow>
+        <boxGeometry args={[1, 2, 1]} />
+        <meshStandardMaterial color="red" />
+      </mesh>
+    </>
+  )
+}
+```
+
+---
+
+## 🎉 What You Have Now
+
+- ✅ A realistic wooden floor
+- ✅ Plaster walls that look like real architecture
+- ✅ Walls with customizable holes for doors or windows
+- ✅ A reflective window with frame
+- ✅ A modern 3D room that's ready to be expanded
+
+Your scene has officially transformed from a blank white box into a beautiful virtual room — the perfect foundation for your interactive 3D profile website.
+
+---
+
+## 🚀 What's Next (Part 3)
+
+In the next part, we'll take this even further:
+
+- ✨ Add furniture and props (like a desk, chair, or laptop)
+- ✨ Animate parts of the scene (like a spinning chair or floating objects)
+- ✨ Experiment with materials, lighting moods, and even environment maps
+
+Stay tuned — your 3D profile is about to come to life!
+
+---
+
+## 📦 Get the Source Code
+
+Want to explore the full working project or customize it yourself?
+
+👉 Check out the source code on GitHub: https://github.com/myoxine/3d-profile/tree/part2

--- a/docs/part3.md
+++ b/docs/part3.md
@@ -367,6 +367,4 @@ Your 3D profile website is getting closer to becoming a fully immersive experien
 
 ## 📦 Full Source Code
 
-👉 Check out the full project here: https://github.com/myoxine/3d-profile/tree/part3
-
-See the `part3` branch for the latest code.
+👉 Explore the complete code for this part on the [`part3` branch](https://github.com/myoxine/3d-profile/tree/part3).

--- a/docs/part3.md
+++ b/docs/part3.md
@@ -353,13 +353,14 @@ Your 3D website is no longer just a white box — it's transforming into your ow
 
 ---
 
-## 🚀 Next Up…
+## 🚀 Next Up… (Part 4)
 
-In the next part, we'll:
+In the next part, we'll make the room feel like a real architectural space:
 
-- Explore lighting moods for different atmospheres
-- Add environment maps for ultra-realistic reflections
-- Make objects clickable for interactivity
+- 🚪 A realistic **3D door** with frame, handle, and hinges
+- 🧱 A **ceiling** to fully enclose the room
+- 🌅 **HDRI environment lighting** for ultra-realistic reflections and global illumination
+- ☀️ A **directional light** that casts believable shadows
 
 Your 3D profile website is getting closer to becoming a fully immersive experience!
 

--- a/docs/part3.md
+++ b/docs/part3.md
@@ -182,6 +182,8 @@ pivotRef.current.rotation.y = Math.sin(time * speed) * maxAngle
 
 A gentle sway makes it feel alive without making your visitors seasick. 😉
 
+> 🔄 **Evolution note (final code).** In the finished project this rocking animation is **disabled** — the `useFrame` rotation is commented out and the chair sits still. Once the room filled up with people, a desktop you focus the camera on, and click-to-focus navigation (Parts 7–9), a perpetually swaying chair became a distraction rather than a delight. The component (`AnimatedSpinningChair` → `GamingChair`) is kept exactly as below; only the one rotation line is commented out. Re-enable it any time by uncommenting `pivotRef.current.rotation.y = angle`.
+
 ---
 
 ## Loading the Adjustable Desk
@@ -234,7 +236,7 @@ export const Room = () => {
       <Wall
         wallSize={[3.1, 4]}
         position={[1.5, 0, -0.05]}
-        rotationY={0.5 * Math.PI}
+        rotation={[0, 0.5 * Math.PI, 0]}
         holePosition={[0.5, -0.2]}
         holeSize={[1.1, 1.6]}
       />
@@ -243,7 +245,7 @@ export const Room = () => {
       <Wall
         wallSize={[3.1, 4]}
         position={[-1.5, 0, -0.05]}
-        rotationY={0.5 * Math.PI}
+        rotation={[0, 0.5 * Math.PI, 0]}
       />
 
       {/* Window */}
@@ -309,25 +311,29 @@ Finally, integrate your `Room` and `Loader`:
 ```tsx
 // src/App.tsx
 
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
 import { Room } from './components/Room'
 import { Loader } from './components/Loader'
 
 export default function App() {
   return (
-    <Canvas
-      shadows
-      camera={{ fov: 50, position: [0, 2, 5] }}
-      style={{ height: '100vh', width: '100vw' }}
-    >
-      <Suspense fallback={<Loader />}>
-        <Room />
-      </Suspense>
-    </Canvas>
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+        <ambientLight intensity={1} />
+        <directionalLight position={[0, 2, 3]} intensity={1} castShadow />
+        <OrbitControls />
+        <Suspense fallback={<Loader />}>
+          <Room />
+        </Suspense>
+      </Canvas>
+    </div>
   )
 }
 ```
+
+> 🎥 We keep the **same camera** (`position={[0, 2, 1]}`, `fov={60}`) and the `OrbitControls` + lights from Parts 1–2 — Part 3 only *adds* the `Suspense` + `Loader` so the screen isn't blank while the GLB models stream in.
 
 ✅ This ensures:
 

--- a/docs/part3.md
+++ b/docs/part3.md
@@ -1,0 +1,366 @@
+# 3D Profile Website - Part 3: Bringing Your Room to Life with 3D Models and Animation
+
+Welcome back to our **3D Profile Website** journey!
+
+So far, we've built a beautiful virtual room with textured walls, floors, and a shiny window. But let's be real: right now it's still an empty shell.
+
+In Part 3, we're going to furnish it with real 3D furniture and make things move!
+
+By the end of this part, you'll have:
+
+- ✅ A realistic gaming chair gently rocking left and right (so cool!)
+- ✅ An adjustable desk sitting perfectly in the room
+- ✅ A cozy, believable 3D workspace to call your own
+
+Let's dive in.
+
+---
+
+## Why Add Furniture and Animation?
+
+Your scene might look beautiful — but it's empty. A virtual room without furniture feels like an unfurnished apartment. Cold. Echoey. Lonely.
+
+Adding models like chairs, desks, plants, and more is what makes your 3D profile website feel personal and alive.
+
+And animation? That's the icing on the cake. Even small movements, like a gently rocking chair, make your scene feel truly alive.
+
+---
+
+## How We'll Do This
+
+Here's what we're building today:
+
+- **Gaming Chair Model** → loaded from a `.glb` file
+- **Adjustable Desk Model** → loaded from a `.glb` file
+- **Animated Chair Component** → rocking left and right instead of spinning endlessly
+- **Room Layout** → placing all objects into our 3D space
+- **Loading Indicator** → to avoid blank screens while models load
+
+---
+
+## Step 1 — Download Your Textures
+
+We'll use these two objects from Poly Pizza and Free3D:
+
+- **Desk:** Adjustable Desk
+- **Chair:** Gaming Chair
+
+Download the GLB files and save them in your project under `public/models/`.
+
+Example folder structure:
+
+```
+public/
+  models/
+    Adjustable Desk.glb
+    gaming chair.glb
+```
+
+Copy your models into `public/models` so they're accessible in your app.
+
+---
+
+## Converting GLB Models into Components
+
+We're using the fantastic tool:
+
+```bash
+npx gltfjsx your-model.glb -t
+```
+
+This command takes your exported `.glb` 3D model and generates a fully ready-to-use React component in TypeScript.
+
+✨ Benefits:
+
+- Models become reusable React components
+- Mesh hierarchies are preserved
+- Materials are imported automatically
+- Position, scale, and rotation stay intact
+
+✅ Your models in this tutorial:
+
+- `/models/gaming chair.glb`
+- `/models/Adjustable Desk.glb`
+
+---
+
+## Let's Load the Gaming Chair
+
+The code for the gaming chair looks like this (simplified):
+
+```tsx
+export function Model(props: JSX.IntrinsicElements['group']) {
+  const { nodes, materials } = useGLTF('/models/gaming chair.glb') as unknown as GLTFResult
+  return (
+    <group {...props} dispose={null}>
+      <group position={[16.339, -7.043, 105.163]} scale={287.601}>
+        <mesh geometry={nodes.Group21.geometry} material={materials.lambert112SG} />
+        {/* many more meshes */}
+      </group>
+    </group>
+  )
+}
+```
+
+> ⚠️ **Note:** Your chair model is massive, so we'll scale it down dramatically when we add it to the scene.
+
+---
+
+## Animating the Chair
+
+Instead of spinning endlessly like a carnival ride, let's make our gaming chair rock left and right gently, just like a real chair when you fidget around.
+
+We'll use a sine wave to rotate the chair smoothly left and right.
+
+✅ Benefits of rocking motion:
+
+- Looks more natural
+- Adds life to the scene
+- Easy to control speed and range
+
+### The AnimatedSpinningChair Component
+
+Here's your TypeScript code to make it happen:
+
+```tsx
+// src/components/AnimatedSpinningChair.tsx
+
+import React, { useRef } from 'react'
+import { Group } from 'three'
+import { useFrame } from '@react-three/fiber'
+import { Model as GamingChair } from './GamingChair'
+import type { JSX } from 'react'
+
+export const AnimatedSpinningChair: React.FC<JSX.IntrinsicElements['group']> = (props) => {
+  const pivotRef = useRef<Group>(null)
+  const chairScale = 1.2 / 575.2021484375
+
+  useFrame(({ clock }) => {
+    const time = clock.getElapsedTime()
+    const maxAngle = 0.3 // ~17 degrees
+    const speed = 1
+
+    // Rock left and right in a sine wave
+    const angle = Math.sin(time * speed) * maxAngle
+
+    if (pivotRef.current) {
+      pivotRef.current.rotation.y = angle
+    }
+  })
+
+  return (
+    <group {...props}>
+      {/* Outer group for positioning */}
+      <group ref={pivotRef} position={[0, 0, 0.24]}>
+        {/* Offset the model back relative to pivot point */}
+        <GamingChair
+          position={[0, 0, -0.24]}
+          scale={[chairScale, chairScale, chairScale]}
+        />
+      </group>
+    </group>
+  )
+}
+```
+
+### How the Animation Works
+
+Instead of spinning forever like this:
+
+```tsx
+pivotRef.current.rotation.y += delta * 0.5
+```
+
+…we gently rock left and right like so:
+
+```tsx
+pivotRef.current.rotation.y = Math.sin(time * speed) * maxAngle
+```
+
+- `speed` → controls how fast the rocking motion is
+- `maxAngle` → sets how far the chair rocks to each side
+
+A gentle sway makes it feel alive without making your visitors seasick. 😉
+
+---
+
+## Loading the Adjustable Desk
+
+Your adjustable desk comes in as another gltfjsx component. Example usage:
+
+```tsx
+import { Model as Desk } from './Desk'
+
+<Desk
+  scale={[deskScale, deskScale, deskScale]}
+  rotation={[0, -0.5 * Math.PI, 0]}
+  position={[0.75, -2 + 0.1, -1.15]}
+/>
+```
+
+---
+
+## Assembling the Full Room
+
+Here's the full `Room` component with:
+
+- Walls and window
+- Floor
+- Desk
+- Animated gaming chair
+
+👇 Copy this into your `Room.tsx`:
+
+```tsx
+// src/components/Room.tsx
+
+import { Floor } from './Floor'
+import { Wall } from './Wall'
+import { Window } from './Window'
+import { Model as Desk } from './Desk'
+import { AnimatedSpinningChair } from './AnimatedSpinningChair'
+
+export const Room = () => {
+  const deskScale = 1.5 / 2
+
+  return (
+    <>
+      <Floor position={[0, -2 + 0.05, 0]} />
+
+      {/* Back wall */}
+      <Wall wallSize={[3, 4]} position={[0, 0, -1.6]} />
+
+      {/* Right wall with window hole */}
+      <Wall
+        wallSize={[3.1, 4]}
+        position={[1.5, 0, -0.05]}
+        rotationY={0.5 * Math.PI}
+        holePosition={[0.5, -0.2]}
+        holeSize={[1.1, 1.6]}
+      />
+
+      {/* Left wall */}
+      <Wall
+        wallSize={[3.1, 4]}
+        position={[-1.5, 0, -0.05]}
+        rotationY={0.5 * Math.PI}
+      />
+
+      {/* Window */}
+      <Window
+        width={1}
+        height={1.5}
+        frameThickness={0.05}
+        position={[1.55, -0.2, -0.55]}
+        rotation={[0, 0.5 * Math.PI, 0]}
+      />
+
+      {/* Desk */}
+      <Desk
+        scale={[deskScale, deskScale, deskScale]}
+        rotation={[0, -0.5 * Math.PI, 0]}
+        position={[0.75, -2 + 0.1, -1.15]}
+      />
+
+      {/* Rocking gaming chair */}
+      <AnimatedSpinningChair
+        position={[0.55, -2 + 0.7, -0.2]}
+        rotation={[0, -Math.PI, 0]}
+      />
+    </>
+  )
+}
+```
+
+---
+
+## Add a Loading Indicator
+
+Don't leave users staring at a blank screen. Let's add a friendly loading bar!
+
+```tsx
+// src/components/Loader.tsx
+
+import { Html, useProgress } from '@react-three/drei'
+
+export function Loader() {
+  const { progress } = useProgress()
+
+  return (
+    <Html center>
+      <div style={{
+        background: '#222',
+        padding: '10px 20px',
+        borderRadius: '8px',
+        color: 'white',
+        fontFamily: 'sans-serif',
+      }}>
+        Loading... {progress.toFixed(0)}%
+      </div>
+    </Html>
+  )
+}
+```
+
+This floats text over your canvas like: `Loading… 53%`
+
+Finally, integrate your `Room` and `Loader`:
+
+```tsx
+// src/App.tsx
+
+import React, { Suspense } from 'react'
+import { Canvas } from '@react-three/fiber'
+import { Room } from './components/Room'
+import { Loader } from './components/Loader'
+
+export default function App() {
+  return (
+    <Canvas
+      shadows
+      camera={{ fov: 50, position: [0, 2, 5] }}
+      style={{ height: '100vh', width: '100vw' }}
+    >
+      <Suspense fallback={<Loader />}>
+        <Room />
+      </Suspense>
+    </Canvas>
+  )
+}
+```
+
+✅ This ensures:
+
+- Loader appears while GLTF models load
+- Room shows only when ready
+- Smooth experience for your visitors
+
+---
+
+## ✨ What You've Built
+
+- ✅ A stylish 3D room with real furniture
+- ✅ A gaming chair rocking gently left and right
+- ✅ A cozy virtual workspace perfect for your portfolio
+
+Your 3D website is no longer just a white box — it's transforming into your own personal space.
+
+---
+
+## 🚀 Next Up…
+
+In the next part, we'll:
+
+- Explore lighting moods for different atmospheres
+- Add environment maps for ultra-realistic reflections
+- Make objects clickable for interactivity
+
+Your 3D profile website is getting closer to becoming a fully immersive experience!
+
+---
+
+## 📦 Full Source Code
+
+👉 Check out the full project here: https://github.com/myoxine/3d-profile/tree/part3
+
+See the `part3` branch for the latest code.

--- a/docs/part3.md
+++ b/docs/part3.md
@@ -343,17 +343,17 @@ export default function App() {
 
 ---
 
-## ✨ What You've Built
+## Lessons Learned in Part 3
 
-- ✅ A stylish 3D room with real furniture
-- ✅ A gaming chair rocking gently left and right
-- ✅ A cozy virtual workspace perfect for your portfolio
-
-Your 3D website is no longer just a white box — it's transforming into your own personal space.
+- **`gltfjsx` turns a `.glb` into a typed React component** — meshes, materials, and transforms preserved, ready to drop into the scene.
+- **Downloaded models come at wild scales.** Expect to divide by hundreds (our chair was ~575×) — normalize with a single `scale` factor instead of guessing.
+- **A sine wave beats an endless spin.** `Math.sin(time * speed) * maxAngle` rocks an object back and forth; `speed` and `maxAngle` are your whole animation API. (In the final project we leave it static — see the evolution note above.)
+- **`<Suspense fallback={<Loader />}>` prevents the blank-screen wait** while heavy GLBs stream in.
+- Your 3D website is no longer just a white box — it's transforming into your own personal space.
 
 ---
 
-## 🚀 Next Up… (Part 4)
+## What's Next (Part 4)
 
 In the next part, we'll make the room feel like a real architectural space:
 
@@ -363,6 +363,14 @@ In the next part, we'll make the room feel like a real architectural space:
 - ☀️ A **directional light** that casts believable shadows
 
 Your 3D profile website is getting closer to becoming a fully immersive experience!
+
+---
+
+## Asset Credits
+
+- **Adjustable Desk** — [Poly Pizza](https://poly.pizza/) (free)
+- **Gaming Chair** — [Free3D](https://free3d.com/) (free)
+- Model-to-component pipeline — [gltfjsx](https://github.com/pmndrs/gltfjsx)
 
 ---
 

--- a/docs/part4.md
+++ b/docs/part4.md
@@ -359,19 +359,17 @@ export default function App() {
 
 ---
 
-## What You've Built
+## Lessons Learned in Part 4
 
-- ✅ A fully enclosed room with a door and ceiling
-- ✅ Natural HDRI lighting for realism
-- ✅ Shadows from directional light
-- ✅ Smooth user exploration with OrbitControls
-- ✅ A cozy environment perfect for a portfolio or interactive website
-
-Your 3D website is evolving from a collection of models into a real virtual space.
+- **A ceiling is what makes a room read as a room.** Enclosing the space traps light and grounds shadows — without it, the scene feels like an open diorama.
+- **HDRI lighting does what point lights can't.** One `<Environment>` map gives soft global illumination *and* realistic reflections for free.
+- **HDRI alone casts no shadows** — pair it with a `directionalLight` (`castShadow`) for sun-like rays and grounding.
+- **Debug scaffolding is for you, not for shipping.** The `console.log('Model Door Size')` here is handy while scaling, but strip it before release (we do, in Part 10).
+- Your 3D website is evolving from a collection of models into a real virtual space.
 
 ---
 
-## Coming Up Next… (Part 5)
+## What's Next (Part 5)
 
 In the next part we'll make the room **interactive and atmospheric**:
 
@@ -383,6 +381,14 @@ In the next part we'll make the room **interactive and atmospheric**:
 (Sound effects and online deployment come later in the series — Parts 12 and 13.)
 
 Your 3D profile website is on its way to becoming a stunning interactive portfolio!
+
+---
+
+## Asset Credits
+
+- **Single Door** (frame, handle, hinges) — [CGTrader](https://www.cgtrader.com/) (free; check terms)
+- **HDRI** — *Dikhololo Sunset* from [Poly Haven](https://polyhaven.com/) (CC0)
+- Built with [React Three Fiber](https://r3f.docs.pmnd.rs/) and [drei](https://github.com/pmndrs/drei)
 
 ---
 

--- a/docs/part4.md
+++ b/docs/part4.md
@@ -127,6 +127,20 @@ export const Room = () => {
 
 Boom — you have a realistic 3D door with hinges!
 
+> 🔄 **Evolution note (final code).** Two things changed later. (1) The `useLayoutEffect` with `console.log('Model Door Size')` above is **debug scaffolding** — handy while you dial in the scale, but remove it before shipping (we clean it up in Part 10). (2) This door's baked `Door_colors` texture rendered as a distracting woven/grid pattern under compression, so in the final project we **drop the glTF materials and assign plain inline materials instead** — a warm off-white panel and near-black metal for the handle and hinges:
+>
+> ```tsx
+> <mesh geometry={nodes.Cube157.geometry} castShadow receiveShadow>
+>   <meshStandardMaterial color="#d8d3c8" roughness={0.8} metalness={0} />
+> </mesh>
+> <mesh geometry={nodes.Cube157_1.geometry} castShadow receiveShadow>
+>   <meshStandardMaterial color="#141414" roughness={0.4} metalness={0.6} />
+> </mesh>
+> <mesh geometry={nodes.Cube157_2.geometry} castShadow receiveShadow>
+>   <meshStandardMaterial color="#141414" roughness={0.4} metalness={0.6} />
+> </mesh>
+> ```
+
 ---
 
 ## Step 2 — Add a Modern Ceiling
@@ -207,6 +221,8 @@ This instantly:
 - ✅ Adds global ambient light
 - ✅ Generates realistic reflections on materials
 - ✅ Makes your space feel alive
+
+> 🔄 **Evolution note (final code).** We load the **4k** HDRI here for the nicest preview, but a 4k `.hdr` is heavy (several MB). In the final project — once the page weight became a real concern (Part 10) — we switch to the **1k** version, `dikhololo_sunset_1k.hdr`. For a room this size, lit mostly by our own lamps, the 1k environment is visually indistinguishable and loads far faster. If you're optimizing, grab the 1k download from Poly Haven and update the `files` path.
 
 ---
 
@@ -357,12 +373,14 @@ Your 3D website is evolving from a collection of models into a real virtual spac
 
 ## Coming Up Next…
 
-In the next part of this series, we'll:
+In the next part (Part 5), we'll make the room **interactive and atmospheric**:
 
-- Add clickable interactivity to objects
-- Enable color and material customization
-- Integrate sound effects for a multi-sensory experience
-- Explore lighting presets for day, night, or dramatic moods
+- A central lighting "brain" any component can read and control
+- **Clickable 3D light switches** that physically flip
+- An LED ceiling, a standing lamp, and a table lamp that emit real light
+- Automatic **day / night** that follows your system's dark mode
+
+(Sound effects and online deployment come later in the series — Parts 12 and 13.)
 
 Your 3D profile website is on its way to becoming a stunning interactive portfolio!
 

--- a/docs/part4.md
+++ b/docs/part4.md
@@ -1,0 +1,382 @@
+# 3D Profile Website - Part 4: Doors, Ceilings & Setting the Mood with Light
+
+Welcome back to our **3D Profile Website** journey!
+
+By now, you have a virtual room with walls, a floor, a shiny window, and real 3D furniture. It's starting to look awesome — but it still feels a bit empty and exposed.
+
+In Part 4, we're going to make your room feel like a real architectural space by adding:
+
+- ✅ A realistic 3D door with frame and hinges
+- ✅ A modern ceiling to enclose the room
+- ✅ An HDRI environment map for beautiful lighting and reflections
+- ✅ Directional light to cast realistic shadows
+- ✅ Orbit controls so visitors can explore your space
+- ✅ Proper credits for all the amazing free assets we're using
+
+By the end of this tutorial, your 3D website will feel like a real room — no longer just floating in a blank void!
+
+Let's dive in.
+
+---
+
+## Why Doors, Ceilings & Lighting Matter
+
+Think about how a real room feels:
+
+- **Doors** create a sense of scale and purpose. They connect spaces.
+- **Ceilings** trap the light and make shadows look believable. Without a ceiling, your space feels like an open diorama.
+- **HDRI lighting** creates reflections and global illumination that pure lights can't easily replicate.
+- **Directional lights** produce shadows that give depth and realism.
+- **Interactive controls** let users explore your scene from any angle.
+
+These details are what transform your scene from "just a 3D model" into a virtual experience.
+
+---
+
+## Step 1 — Add the Door Model
+
+We're using this free door model:
+
+👉 Single Door with Molds, Frame, Handle and Hinges on CGTrader
+
+- **License:** Free for personal and commercial use (check CGTrader's terms)
+- **Format:** `.glb`
+- **Details:** This door comes complete with frames, handles, and hinges for realism.
+
+Download the GLB file and save it in your project under `public/models/`.
+
+### Converting the Door to a Component
+
+Run this command:
+
+```bash
+npx gltfjsx Door1_001.glb -t
+```
+
+It generates a React component for your door, preserving all meshes and materials. Your final code looks like this (simplified):
+
+```tsx
+import * as THREE from 'three'
+import { useGLTF } from '@react-three/drei'
+import { useLayoutEffect } from 'react'
+import type { GLTF } from 'three-stdlib'
+import type { JSX } from 'react'
+
+type GLTFResult = GLTF & {
+  nodes: {
+    Cube157: THREE.Mesh
+    Cube157_1: THREE.Mesh
+    Cube157_2: THREE.Mesh
+  }
+  materials: {
+    Door_colors: THREE.MeshStandardMaterial
+    ['Material.001']: THREE.MeshStandardMaterial
+    Hinge: THREE.MeshStandardMaterial
+  }
+}
+
+export function Model(props: JSX.IntrinsicElements['group']) {
+  const { nodes, materials, scene } = useGLTF('/models/uploads_files_3300784_Door1_001.glb') as unknown as GLTFResult
+
+  useLayoutEffect(() => {
+    if (scene) {
+      const box = new THREE.Box3().setFromObject(scene)
+      const size = new THREE.Vector3()
+      box.getSize(size)
+      console.log('Model Door Size:', size)
+    }
+  }, [scene])
+
+  return (
+    <group {...props} dispose={null}>
+      <mesh geometry={nodes.Cube157.geometry} material={materials.Door_colors} />
+      <mesh geometry={nodes.Cube157_1.geometry} material={materials['Material.001']} />
+      <mesh geometry={nodes.Cube157_2.geometry} material={materials.Hinge} />
+    </group>
+  )
+}
+
+useGLTF.preload('/models/uploads_files_3300784_Door1_001.glb')
+```
+
+### Adding the Wall with Door to Your Room
+
+Place your door inside a wall's hole:
+
+```tsx
+...
+import { Model as Door } from './Door'
+
+export const Room = () => {
+  const doorScale = 2.5 / 2.138395843336184
+  ...
+  return (
+    <>
+      ...
+      <Wall wallSize={[3.2, 4]} position={[0, 0, 1.55]} holePosition={[-0.75, -0.65]} holeSize={[0.99, 2.5]} />
+      <Door
+        scale={doorScale}
+        rotation={[0, 0.5 * Math.PI, 0]}
+        position={[-0.75, -1.9, 1.55]}
+      />
+      ...
+    </>
+  )
+}
+```
+
+Boom — you have a realistic 3D door with hinges!
+
+---
+
+## Step 2 — Add a Modern Ceiling
+
+A ceiling is critical for realism. It gives your space a sense of enclosure and helps catch shadows from lights above. Create a new file:
+
+```tsx
+// src/components/Ceiling.tsx
+import type { JSX } from "react"
+
+type CeilingProps = JSX.IntrinsicElements['group'] & {
+  size?: [number, number]
+}
+
+export function Ceiling({ size, ...props }: CeilingProps) {
+  return (
+    <group {...props}>
+      <mesh castShadow receiveShadow>
+        <planeGeometry args={size} />
+        <meshStandardMaterial color="#111" metalness={0.7} roughness={0.4} />
+      </mesh>
+    </group>
+  )
+}
+```
+
+Add it to the room:
+
+```tsx
+<Ceiling
+  size={[3, 3]}
+  position={[0, 1.9, 0]}
+  rotation={[Math.PI * 0.5, 0, 0]}
+/>
+```
+
+---
+
+## Step 3 — Add HDRI Lighting
+
+HDRIs are high dynamic range images that wrap around your scene and create beautiful reflections and global illumination.
+
+We're using this HDRI:
+
+👉 Dikhololo Sunset on Poly Haven
+
+- **License:** CC0 (public domain) — free for all uses
+- **Vibes:** Warm sunset glow, perfect for a cozy workspace
+
+Download the HDR file and save it in your project under `public/hdri/`.
+
+Then add the HDRI to your canvas:
+
+```tsx
+...
+import { Environment } from '@react-three/drei'
+
+export default function App() {
+  return (
+    <div style={{ width: "100vw", height: "100vh" }}>
+      <Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+        <Suspense fallback={<Loader />}>
+          <Environment
+            files="/hdri/dikhololo_sunset_4k.hdr"
+            background
+            environmentIntensity={0.3}
+          />
+          ...
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}
+```
+
+This instantly:
+
+- ✅ Adds global ambient light
+- ✅ Generates realistic reflections on materials
+- ✅ Makes your space feel alive
+
+---
+
+## Step 4 — Add Directional Lighting
+
+While HDRI creates soft global light, it doesn't cast shadows. Add a directional light for sun-like rays and shadows:
+
+```tsx
+<directionalLight
+  color="#ffffff"
+  intensity={0.5}
+  position={[3, 1, -2]}
+  castShadow
+  shadow-mapSize-width={2048}
+  shadow-mapSize-height={2048}
+  shadow-camera-far={50}
+  shadow-camera-left={-5}
+  shadow-camera-right={5}
+  shadow-camera-top={5}
+  shadow-camera-bottom={-5}
+/>
+```
+
+✅ This provides:
+
+- Sharp shadows
+- Directional sunlight effect
+
+---
+
+## Step 5 — Complete Room Code
+
+Here's your updated `Room.tsx`:
+
+```tsx
+import { Floor } from './Floor'
+import { Wall } from './Wall'
+import { Window } from './Window'
+import { Model as Desk } from './Desk'
+import { AnimatedSpinningChair } from './AnimatedSpinningChair'
+import { Ceiling } from './Ceiling'
+import { Model as Door } from './Door'
+
+export const Room = () => {
+  const deskScale = 1.5 / 2
+  const doorScale = 2.5 / 2.138395843336184
+
+  return (
+    <>
+      <Floor position={[0, -2 + 0.05, 0]} />
+
+      {/* Walls */}
+      <Wall wallSize={[3, 4]} position={[0, 0, -1.55]} />
+      <Wall wallSize={[3.2, 4]} position={[1.55, 0, 0]} rotation={[0, 0.5 * Math.PI, 0]} holePosition={[0.54, -0.2]} holeSize={[1.1, 1.6]} />
+      <Wall wallSize={[3.2, 4]} position={[-1.55, 0, 0]} rotation={[0, 0.5 * Math.PI, 0]} />
+      <Wall wallSize={[3.2, 4]} position={[0, 0, 1.55]} holePosition={[-0.75, -0.65]} holeSize={[0.99, 2.5]} />
+
+      {/* Window */}
+      <Window
+        width={1}
+        height={1.5}
+        frameThickness={0.05}
+        position={[1.55, -0.2, -0.54]}
+        rotation={[0, 0.5 * Math.PI, 0]}
+      />
+
+      {/* Door */}
+      <Door
+        scale={doorScale}
+        rotation={[0, 0.5 * Math.PI, 0]}
+        position={[-0.75, -1.9, 1.55]}
+      />
+
+      {/* Desk */}
+      <Desk
+        scale={[deskScale, deskScale, deskScale]}
+        rotation={[0, -0.5 * Math.PI, 0]}
+        position={[0.75, -2 + 0.1, -1.15]}
+      />
+
+      {/* Ceiling */}
+      <Ceiling
+        size={[3, 3]}
+        position={[0, 1.9, 0]}
+        rotation={[0.5 * Math.PI, 0, 0]}
+      />
+
+      {/* Animated rocking chair */}
+      <AnimatedSpinningChair
+        position={[0.55, -2 + 0.7, -0.2]}
+        rotation={[0, -Math.PI, 0]}
+      />
+    </>
+  )
+}
+```
+
+And your updated `App.tsx`:
+
+```tsx
+import { Canvas } from '@react-three/fiber'
+import { Suspense } from 'react'
+import { Room } from './components/Room'
+import { Loader } from './components/Loader'
+import { Environment, OrbitControls } from '@react-three/drei'
+
+export default function App() {
+  return (
+    <div style={{ width: "100vw", height: "100vh" }}>
+      <Canvas camera={{ position: [0, 2, 1], fov: 60 }} shadows>
+        <directionalLight
+          color={"#ffffff"}
+          intensity={0.5}
+          position={[3, 1, -2]}
+          castShadow
+          shadow-mapSize-width={2048}
+          shadow-mapSize-height={2048}
+          shadow-camera-far={50}
+          shadow-camera-left={-5}
+          shadow-camera-right={5}
+          shadow-camera-top={5}
+          shadow-camera-bottom={-5}
+        />
+        <Suspense fallback={<Loader />}>
+          <Environment files="/hdri/dikhololo_sunset_4k.hdr" background environmentIntensity={0.3} />
+          <OrbitControls />
+          <Room />
+        </Suspense>
+      </Canvas>
+    </div>
+  )
+}
+```
+
+---
+
+## What You've Built
+
+- ✅ A fully enclosed room with a door and ceiling
+- ✅ Natural HDRI lighting for realism
+- ✅ Shadows from directional light
+- ✅ Smooth user exploration with OrbitControls
+- ✅ A cozy environment perfect for a portfolio or interactive website
+
+Your 3D website is evolving from a collection of models into a real virtual space.
+
+---
+
+## Coming Up Next…
+
+In the next part of this series, we'll:
+
+- Add clickable interactivity to objects
+- Enable color and material customization
+- Integrate sound effects for a multi-sensory experience
+- Explore lighting presets for day, night, or dramatic moods
+
+Your 3D profile website is on its way to becoming a stunning interactive portfolio!
+
+---
+
+## 📦 Full Source Code
+
+👉 Check out the full project here: https://github.com/myoxine/3d-profile/tree/part4
+
+The `part4` branch contains:
+
+- The updated Room component
+- The Door and Ceiling components
+- Lighting and HDRI setup
+- All code shown in this tutorial
+
+Feel free to clone it, explore it, and customize it for your own 3D website!

--- a/docs/part4.md
+++ b/docs/part4.md
@@ -371,9 +371,9 @@ Your 3D website is evolving from a collection of models into a real virtual spac
 
 ---
 
-## Coming Up Next…
+## Coming Up Next… (Part 5)
 
-In the next part (Part 5), we'll make the room **interactive and atmospheric**:
+In the next part we'll make the room **interactive and atmospheric**:
 
 - A central lighting "brain" any component can read and control
 - **Clickable 3D light switches** that physically flip

--- a/docs/part4.md
+++ b/docs/part4.md
@@ -388,7 +388,7 @@ Your 3D profile website is on its way to becoming a stunning interactive portfol
 
 ## 📦 Full Source Code
 
-👉 Check out the full project here: https://github.com/myoxine/3d-profile/tree/part4
+👉 Explore the complete code for this part on the [`part4` branch](https://github.com/myoxine/3d-profile/tree/part4).
 
 The `part4` branch contains:
 

--- a/docs/part5.md
+++ b/docs/part5.md
@@ -114,6 +114,8 @@ export function useLighting() {
 
 > 💡 We put the provider **inside** the `<Canvas>` so every 3D component (switches, lamps, environment) can call `useLighting()`.
 
+> 🔄 **Evolution note (final code).** Two later refinements: (1) The finished project **defaults the ceiling lamp ON when the system is in dark mode / night** — a pitch-black room on first load looked broken, so `ceilingOn` is initialized from the same `prefers-color-scheme` check (`useState(getSystemTimeOfDay() === 'night')`) and the media-query handler flips it live. (2) A **fourth lamp + switch** (`sofaOn` / `toggleSofa`, for the lamps behind the sofa) is added in Part 7, so the final `LightingState` has four toggles, not three.
+
 ---
 
 ## Step 3 — A Day / Night Environment

--- a/docs/part5.md
+++ b/docs/part5.md
@@ -383,20 +383,31 @@ To make the space feel lived-in, we drop in a few more GLB props. Each is conver
 
 ---
 
-## What You've Built
+## Lessons Learned in Part 5
 
-✅ A central lighting system any component can read and control
-✅ Clickable 3D switches with a satisfying rocker flip
-✅ An LED ceiling, a standing lamp, and a table lamp that emit real light
-✅ Automatic day / night that follows the user's system theme
-✅ Bloom glow that sells the light sources
-✅ A cozy, furnished room — sofa, AC, credenza, plant
-
-Your 3D website is no longer just a model you orbit around — it's a little space people can **interact with**.
+- **State, not props, for cross-cutting concerns.** Lighting touches switches, lamps, and the environment — a central Context (or store) beats threading booleans through the whole tree.
+- **Emissive + Bloom = believable light.** A bulb that doesn't visibly glow looks fake; make it `emissive` with `toneMapped={false}` and let Bloom bleed the bright parts.
+- **Respect the user's context.** Read `prefers-color-scheme` for day/night instead of guessing — and update it live with a `matchMedia` listener.
+- **Animate the *button*, not the frame.** The switch's rocker flips via `useFrame` + `lerp` while the GLB plate stays put — small, physical, satisfying.
+- **Watch your `.glb` sizes.** One bloated model tanks load time; prefer low-poly or compress (the focus of Part 10).
+- Your 3D website is no longer just a model you orbit around — it's a little space people can **interact with**.
 
 ---
 
-## Credits
+## What's Next (Part 6)
+
+The room is interactive — next we make it **personal**, filling it with *your* content:
+
+- 💻 A **laptop and a monitor** on the desk
+- 📺 A **TV you can click to play a YouTube video** right on the screen
+- 🖼️ A reusable **PhotoFrame** component and a **gallery wall** of your photo, diplomas, and certificates
+- 📄 A practical workflow to turn **PDFs and images into web-ready textures**
+
+Your 3D profile website is well on its way to becoming a stunning interactive portfolio!
+
+---
+
+## Asset Credits
 
 All 3D assets below are free models — please check each asset's license before commercial use.
 
@@ -408,19 +419,6 @@ All 3D assets below are free models — please check each asset's license before
 - **Plant (Cordyline glauca):** [CGTrader](https://www.cgtrader.com/items/6315999/download-page)
 - **HDRI:** *Dikhololo Sunset* — [Poly Haven](https://polyhaven.com/) (CC0)
 - Built with [React Three Fiber](https://r3f.docs.pmnd.rs/), [drei](https://github.com/pmndrs/drei), and [postprocessing](https://github.com/pmndrs/react-postprocessing).
-
----
-
-## Coming Up Next… (Part 6)
-
-The room is interactive — next we make it **personal**, filling it with *your* content:
-
-- 💻 A **laptop and a monitor** on the desk
-- 📺 A **TV you can click to play a YouTube video** right on the screen
-- 🖼️ A reusable **PhotoFrame** component and a **gallery wall** of your photo, diplomas, and certificates
-- 📄 A practical workflow to turn **PDFs and images into web-ready textures**
-
-Your 3D profile website is well on its way to becoming a stunning interactive portfolio!
 
 ---
 

--- a/docs/part5.md
+++ b/docs/part5.md
@@ -411,14 +411,14 @@ All 3D assets below are free models — please check each asset's license before
 
 ---
 
-## Coming Up Next…
+## Coming Up Next… (Part 6)
 
-In the next part we'll keep pushing the interactivity:
+The room is interactive — next we make it **personal**, filling it with *your* content:
 
-- Clickable objects that reveal info (projects, about, contact)
-- Smooth camera transitions to focus on areas of the room
-- Sound effects for a multi-sensory feel
-- Saving the user's light preferences
+- 💻 A **laptop and a monitor** on the desk
+- 📺 A **TV you can click to play a YouTube video** right on the screen
+- 🖼️ A reusable **PhotoFrame** component and a **gallery wall** of your photo, diplomas, and certificates
+- 📄 A practical workflow to turn **PDFs and images into web-ready textures**
 
 Your 3D profile website is well on its way to becoming a stunning interactive portfolio!
 

--- a/docs/part5.md
+++ b/docs/part5.md
@@ -426,7 +426,9 @@ Your 3D profile website is well on its way to becoming a stunning interactive po
 
 ## 📦 Full Source Code
 
-👉 The `part5` branch contains everything from this tutorial:
+👉 Explore the complete code for this part on the [`part5` branch](https://github.com/myoxine/3d-profile/tree/part5).
+
+The `part5` branch contains everything from this tutorial:
 - The `LightingContext` + day/night logic
 - Interactive `LightSwitch`, the LED `Ceiling`, `StandingLamp`, and `TableLamp`
 - Bloom setup and all the new furniture

--- a/docs/part6.md
+++ b/docs/part6.md
@@ -268,4 +268,6 @@ The room is furnished and personal — next we make it *navigable*.
 
 ## 📦 Full Source Code
 
-👉 The `part6` branch contains everything: the `Laptop`, `Monitor`, and `Tv` components, the reusable `PhotoFrame`, the gallery layout, and the PDF/image pipeline.
+👉 Explore the complete code for this part on the [`part6` branch](https://github.com/myoxine/3d-profile/tree/part6).
+
+The `part6` branch contains everything: the `Laptop`, `Monitor`, and `Tv` components, the reusable `PhotoFrame`, the gallery layout, and the PDF/image pipeline.

--- a/docs/part6.md
+++ b/docs/part6.md
@@ -225,7 +225,7 @@ Two gotchas that cost real time here — and how to fix them:
 
 ---
 
-## Lessons on Asset File Size
+## A Note on Asset File Size
 
 Two models nearly broke this build:
 
@@ -236,27 +236,17 @@ Rules of thumb: inspect every download, prefer low-poly, resize textures, and ke
 
 ---
 
-## What You've Built
+## Lessons Learned in Part 6
 
-✅ A laptop and monitor on the desk
-✅ A clickable TV playing a YouTube video, correctly occluded by the room
-✅ A reusable `PhotoFrame` for any image
-✅ A gallery of your photo, diplomas, and certificates
-✅ A reusable pipeline: PDF → PNG → resized texture
-
-Your room is now unmistakably **yours**.
+- **A reusable component beats one-off meshes.** One `PhotoFrame` with props renders your photo, every diploma, and every certificate — the gallery wall is just data.
+- **Render a video onto a material to make a "playable" screen.** A `<Html>` overlay (or video texture) turns the TV mesh into something a visitor can actually click and watch.
+- **Build a content pipeline, not a pile of exports.** PDF → PNG → resized texture is a repeatable recipe; do it once and every credential drops straight in.
+- **Inspect every download before you trust it.** A "monitor" can secretly be a 47 MB scene; a sofa can be 94 MB. Prefer low-poly, resize textures, keep assets well under ~10 MB.
+- Your room is now unmistakably **yours**.
 
 ---
 
-## Credits
-
-- **Laptop, Monitor, TV** — free GLB models (verify each license before commercial use).
-- Photo, diplomas, and certificates — the author's own.
-- Built with [React Three Fiber](https://r3f.docs.pmnd.rs/), [drei](https://github.com/pmndrs/drei), [pdf-to-img](https://www.npmjs.com/package/pdf-to-img), and [sharp](https://sharp.pixelplumbing.com/).
-
----
-
-## Coming Up Next… (Part 7)
+## What's Next (Part 7)
 
 The room is furnished and personal — but it's empty of people and frozen in time. Next we **bring it to life**:
 
@@ -265,6 +255,14 @@ The room is furnished and personal — but it's empty of people and frozen in ti
 - 🕐 A **wall clock whose hands track your real system time**
 - ✨ A glowing **neon sign** built from extruded 3D letters + Bloom
 - 💡 Two **lamps behind the sofa** wired to a new **4th light switch**
+
+---
+
+## Asset Credits
+
+- **Laptop, Monitor, TV** — free GLB models (verify each license before commercial use).
+- Photo, diplomas, and certificates — the author's own.
+- Built with [React Three Fiber](https://r3f.docs.pmnd.rs/), [drei](https://github.com/pmndrs/drei), [pdf-to-img](https://www.npmjs.com/package/pdf-to-img), and [sharp](https://sharp.pixelplumbing.com/).
 
 ---
 

--- a/docs/part6.md
+++ b/docs/part6.md
@@ -256,13 +256,15 @@ Your room is now unmistakably **yours**.
 
 ---
 
-## Coming Up Next…
+## Coming Up Next… (Part 7)
 
-- Clickable hotspots that focus the camera and reveal info panels (projects, about, contact)
-- A guided tour and smooth camera transitions
-- Deploying your 3D portfolio online
+The room is furnished and personal — but it's empty of people and frozen in time. Next we **bring it to life**:
 
-The room is furnished and personal — next we make it *navigable*.
+- 🧍 **Animated characters** from Mixamo (someone typing at the desk, people on the sofa)
+- 🧑‍🎨 A drop-in pipeline for **Ready Player Me avatars** (real textures, real eyes)
+- 🕐 A **wall clock whose hands track your real system time**
+- ✨ A glowing **neon sign** built from extruded 3D letters + Bloom
+- 💡 Two **lamps behind the sofa** wired to a new **4th light switch**
 
 ---
 

--- a/docs/part7.md
+++ b/docs/part7.md
@@ -268,3 +268,9 @@ Thanks for following the series — go make your room *yours*. 🎬
 - Wall clock, lamp — free GLB/glTF assets (see each model's source license)
 - Typeface — `helvetiker_regular` from the [three.js](https://github.com/mrdoob/three.js) examples
 - Post-processing — [@react-three/postprocessing](https://github.com/pmndrs/react-postprocessing) (Bloom)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part7` branch](https://github.com/myoxine/3d-profile/tree/part7).

--- a/docs/part7.md
+++ b/docs/part7.md
@@ -266,7 +266,7 @@ Thanks for following along — go make your room *navigable* next. 🎬
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Characters & animations — [Mixamo](https://www.mixamo.com) / [Ready Player Me](https://readyplayer.me)
 - Wall clock, lamp — free GLB/glTF assets (see each model's source license)

--- a/docs/part7.md
+++ b/docs/part7.md
@@ -254,11 +254,15 @@ A good reminder: **animation is a choice per object**, not a default. Movement s
 
 ---
 
-## What's Next
+## What's Next (Part 8)
 
-The room is now alive: people, a ticking clock, glowing signage, switchable lamps. From here you could add **scroll-driven camera moves**, **clickable hotspots** that open project details, or **lazy-loading** so the heavy character GLBs stream in after first paint.
+The room is now alive: people, a ticking clock, glowing signage, switchable lamps. But a visitor still has to fly the camera around by hand to find anything. In **Part 8** we turn it into a *guided* experience:
 
-Thanks for following the series — go make your room *yours*. 🎬
+- 🗃️ A **state store (zustand)** that works both inside and outside the R3F Canvas
+- 🎥 Replacing `OrbitControls` with **`CameraControls`** and a set of **named "view" presets** the camera animates to
+- 🧭 A **menu bar** that flies you to each area of the room, plus an **Exit** button
+
+Thanks for following along — go make your room *navigable* next. 🎬
 
 ---
 

--- a/docs/part8.md
+++ b/docs/part8.md
@@ -335,7 +335,7 @@ Thanks for following along — go make your room *navigable*. 🎥
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Brand logos — official SVG paths (each brand's trademark belongs to its owner; used here as link affordances)
 - Camera controls — [`camera-controls`](https://github.com/yomotsu/camera-controls) via [@react-three/drei](https://github.com/pmndrs/drei)

--- a/docs/part8.md
+++ b/docs/part8.md
@@ -340,3 +340,9 @@ Thanks for following along — go make your room *navigable*. 🎥
 - Brand logos — official SVG paths (each brand's trademark belongs to its owner; used here as link affordances)
 - Camera controls — [`camera-controls`](https://github.com/yomotsu/camera-controls) via [@react-three/drei](https://github.com/pmndrs/drei)
 - State — [zustand](https://github.com/pmndrs/zustand)
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part8` branch](https://github.com/myoxine/3d-profile/tree/part8).

--- a/docs/part8.md
+++ b/docs/part8.md
@@ -327,7 +327,7 @@ Books stand **spine-out** so the title is readable, which needs a nested rotatio
 
 ---
 
-## What's Next
+## What's Next (Part 9)
 
 The room is now a guided portfolio: a menu tours every area, objects are clickable, and the camera always behaves. Next we can flesh out the **book & project drawers** (a side panel listing each series' articles, app-style project icons), add **deep links** (open straight into a view via the URL hash), and **lazy-load** the heavy GLBs so the first paint is instant.
 

--- a/docs/part9.md
+++ b/docs/part9.md
@@ -374,7 +374,7 @@ Thanks for following along — go make your room *talk back*. 🖥️
 
 ---
 
-### Asset Credits
+## Asset Credits
 
 - Avatars — [Ready Player Me](https://readyplayer.me/)
 - DOM-in-3D — `<Html>` from [@react-three/drei](https://github.com/pmndrs/drei)

--- a/docs/part9.md
+++ b/docs/part9.md
@@ -366,7 +366,7 @@ It's the same `<Suspense>` you already use for the whole scene — the trick is 
 
 ---
 
-## What's Next
+## What's Next (Part 10)
 
 The room is now genuinely interactive: a desktop you can click, a resume you can read, tooltips that teach, a guided tour, and links you can share. From here the series can turn outward — **performance budgets** (draco/meshopt compression, instancing, on-demand frames), **mobile controls & layout**, and finally **deploying** the whole thing so recruiters can walk through your portfolio from a single link.
 

--- a/docs/part9.md
+++ b/docs/part9.md
@@ -380,3 +380,9 @@ Thanks for following along — go make your room *talk back*. 🖥️
 - DOM-in-3D — `<Html>` from [@react-three/drei](https://github.com/pmndrs/drei)
 - State — [zustand](https://github.com/pmndrs/zustand)
 - Project & experience content — from the author's CV
+
+---
+
+## 📦 Full Source Code
+
+👉 Explore the complete code for this part on the [`part9` branch](https://github.com/myoxine/3d-profile/tree/part9).


### PR DESCRIPTION
Brings the tutorial docs to a complete, consistent state across the whole series. **Docs-only** — no source/code changes. Stacks on the deployment PR (#16); base = `part13`.

## What's in here

**1. Add the missing early tutorials (`part1`–`part4`)**
The docs folder previously started at `part5`. Added Part 1 (project setup + first room), Part 2 (textures, walls-with-holes, reflective window), Part 3 (GLB models + animation), Part 4 (door, ceiling, HDRI), formatted as Markdown to match the rest.

**2. Consistency pass — tutorial vs. final code**
- `Wall`: drop the custom `rotationY` prop in favour of the group-prop `rotation` (matches final `Wall.tsx`); fixed usage in Part 2 & 3.
- Part 3 `App.tsx` camera aligned with Parts 1/2/4; filename-case warning (`gaming chair.glb`) for case-sensitive hosts; `public/HRDI/` typo → `public/hdri/`.
- Evolution notes where the final code moved on: static chair (P3), door inline-materials + debug-log removal & HDRI 4k→1k (P4), ceiling-on default in dark mode + 4th switch (P5).

**3. Standardize GitHub source links**
Every part now ends with a uniform footer linking to its own branch (`tree/partN`). Previously only Part 2–4 had URLs.

**4. Align every "What's Next" with the actual next part**
Fixed 6 mismatched previews (Part 5 → 6, Part 6 → 7, etc.), added the missing one in Part 1, and handed Part 12 off to Part 13 (dropped the premature "finale" claim).

**5. Harmonize structure & writing style**
One canonical template for all 13 parts:
`Intro + ✅ checklist → Why/Concept → Step N — … → Lessons Learned in Part N → What's Next (Part N+1) → Asset Credits → 📦 Full Source Code`
- em-dash step headings everywhere (Part 1 used colons)
- `What You('ve) Built/Have Now` → `Lessons Learned in Part N` (added genuine takeaways to Parts 1–6)
- credits unified to `## Asset Credits` (h2); footer wording unified to `Full Source Code`
- next-section headers unified to `## What's Next (Part N)`

## Not included
The `partN-medium.md` variants are left as-is (separate Medium-publication format); they can be harmonized in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)